### PR TITLE
Move FE origin values to env var

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 src/.DS_Store
 .DS_Store
 .idea/workspace.xml
+.idea/chord-paper-be.iml
+.idea/misc.xml
+.idea/modules.xml
+.idea/vcs.xml


### PR DESCRIPTION
The CORS filter requires an acceptable list of hosts that can call the endpoint. This needs to be configurable, esp due to local development, so moving this to an environment variable where the hosts are comma separated

e.g.
```
ALLOWED_FE_ORIGINS=http://google.com,https://localhost:4000
```