### PR TITLE
Auth payload into header

### DIFF
--- a/src/gateway/auth.rs
+++ b/src/gateway/auth.rs
@@ -1,0 +1,21 @@
+use std::error::Error;
+use std::fmt;
+
+#[derive(Debug, Clone)]
+struct AuthError;
+
+impl fmt::Display for AuthError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Unauthenticated error")
+    }
+}
+
+impl Error for AuthError {}
+
+pub fn extract_bearer_token(auth_header_value: &str) -> Result<String, Box<dyn Error>> {
+    let strip_result = auth_header_value.strip_prefix("Bearer ");
+    match strip_result {
+        Some(auth_token) => Ok(auth_token.to_owned()),
+        None => Err(Box::new(AuthError{}))
+    }
+}

--- a/src/gateway/login.rs
+++ b/src/gateway/login.rs
@@ -1,15 +1,10 @@
-use serde::Deserialize;
-
+use super::auth;
 use crate::usecases;
+use crate::usecases::login::User;
 use http::StatusCode;
 
 pub struct Google {
     usecase: usecases::login::Google,
-}
-
-#[derive(Deserialize)]
-pub struct VerifyLoginRequest {
-    id_token: String,
 }
 
 impl Google {
@@ -19,12 +14,25 @@ impl Google {
         }
     }
 
-    pub fn verify_login(&self, request: VerifyLoginRequest) -> Box<dyn warp::Reply> {
-        let result = self.usecase.verify_login(request.id_token.as_str());
+    pub fn verify_login(&self, user_id: &str, auth_header_value: &str) -> Box<dyn warp::Reply> {
+        let token: String = match auth::extract_bearer_token(&auth_header_value) {
+            Ok(auth_token) => auth_token,
+            Err(error) => {
+                return Box::new( warp::reply::with_status(error.to_string(), StatusCode::UNAUTHORIZED))
+            }
+        };
 
-        match result {
-            Ok(user) => Box::new(warp::reply::json(&user)),
-            Err(error) => Box::new( warp::reply::with_status(error.to_string(), StatusCode::UNAUTHORIZED)),
+        let user: User = match self.usecase.verify_login(&token) {
+            Ok(user) => user,
+            Err(error) => {
+                return Box::new( warp::reply::with_status(error.to_string(), StatusCode::UNAUTHORIZED))
+            },
+        };
+
+        if user.id != user_id {
+            return Box::new( warp::reply::with_status("Requested user ID does not match id token", StatusCode::UNAUTHORIZED))
         }
+
+        Box::new(warp::reply::json(&user))
     }
 }

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -1,1 +1,2 @@
 pub mod login;
+mod auth;

--- a/src/server/serve.rs
+++ b/src/server/serve.rs
@@ -1,25 +1,20 @@
 use std::net::SocketAddr;
 use std::env;
+
 use warp::Filter;
 use crate::gateway;
 
 const GOOGLE_CLIENT_ID: &str = "650853277550-ta69qbfcvdl6tb5ogtnh2d07ae9rcdlf.apps.googleusercontent.com";
 
 pub async fn serve(addr: impl Into<SocketAddr> + 'static) {
-    let fe_origins: Vec<String> = accepted_fe_origins();
-    let fe_origins_ref: Vec<&str> = fe_origins.iter()
-        .map(String::as_str)
-        .collect();
-
     let verify_login = warp::post()
-        .and(warp::path("login"))
-        .and(warp::body::content_length_limit(1024 * 16))
-        .and(warp::body::json())
-        .map(|request: crate::gateway::login::VerifyLoginRequest| {
+        .and(warp::path!("login" / String))
+        .and(warp::header::<String>("authorization"))
+        .map(|user_id: String, auth_value: String| {
             let gateway = gateway::login::Google::new(GOOGLE_CLIENT_ID);
-            gateway.verify_login(request)
+            gateway.verify_login(&user_id, &auth_value)
         })
-        .with(cors_filter(fe_origins_ref, vec!["POST"]));
+        .with(cors_filter(vec!["POST"]));
 
     let paths = verify_login.with(warp::log("info"));
 
@@ -28,11 +23,18 @@ pub async fn serve(addr: impl Into<SocketAddr> + 'static) {
         .await;
 }
 
-fn cors_filter(allowed_origins: Vec<&str>, allowed_methods: Vec<&str>) -> warp::filters::cors::Builder {
+
+
+fn cors_filter(allowed_methods: Vec<&str>) -> warp::filters::cors::Builder {
+    let fe_origins: Vec<String> = accepted_fe_origins();
+    let fe_origins_ref: Vec<&str> = fe_origins.iter()
+        .map(String::as_str)
+        .collect();
+
     warp::cors()
-        .allow_origins(allowed_origins)
+        .allow_origins(fe_origins_ref)
         .allow_methods(allowed_methods)
-        .allow_header("content-type")
+        .allow_headers(vec!["content-type", "authorization"])
 }
 
 fn accepted_fe_origins() -> Vec<String> {

--- a/src/usecases/login.rs
+++ b/src/usecases/login.rs
@@ -3,9 +3,9 @@ use std::error::Error;
 
 #[derive(Serialize)]
 pub struct User {
-    id: String,
-    name: Option<String>,
-    email: Option<String>,
+    pub id: String,
+    pub name: Option<String>,
+    pub email: Option<String>,
 }
 
 pub struct Google {


### PR DESCRIPTION
The auth payload used to live in the post body, but for JWTs the canonical place for them to be received is in the header.

Also adding that the path now by
/login/google_id

so that the response of the login request is not dynamic on the header, except when it's authenticated vs unauthenticated.