### PR TITLE
Shifting over to fork of serde_dynamodb

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1594,8 +1594,7 @@ dependencies = [
 [[package]]
 name = "serde_dynamodb"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bd887fdf521b38d7fa4bdcec1b72dc47d41c085240f453b2cf7dd0242bf3ea4"
+source = "git+https://github.com/veedubyou/serde_dynamodb#b178b1c2083c731cef591abb3554822b0a33008d"
 dependencies = [
  "bytes",
  "rusoto_dynamodb",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,6 @@ serde_json = "*"
 http = "*"
 rusoto_core = "*"
 rusoto_dynamodb = "*"
-serde_dynamodb = "*"
+serde_dynamodb = { git = "https://github.com/veedubyou/serde_dynamodb", branch = "master" }
 snafu = "*"
 uuid = { version = "*", features = ["v4", "serde"] }


### PR DESCRIPTION
Temp (hopefully) shifting over to a fork of serde_dynamodb - keys with empty strings were not being serialized and this causes problems when fetched out as one giant blob later, since there would be missing keys and it would cause deserialization errors in the front end.