### PR TITLE
Update song

### DIFF
--- a/.idea/runConfigurations/Run_chord_paper_be.xml
+++ b/.idea/runConfigurations/Run_chord_paper_be.xml
@@ -11,6 +11,7 @@
       <env name="AWS_ACCESS_KEY_ID" value="local" />
       <env name="AWS_SECRET_ACCESS_KEY" value="local" />
       <env name="ENVIRONMENT" value="development" />
+      <env name="RUST_BACKTRACE" value="full" />
     </envs>
     <method v="2">
       <option name="CARGO.BUILD_TASK_PROVIDER" enabled="true" />

--- a/src/application/songs/gateway.rs
+++ b/src/application/songs/gateway.rs
@@ -38,14 +38,33 @@ impl Gateway {
             Err(err) => map_usecase_errors(err),
         }
     }
+
+    pub async fn update_song(
+        &self,
+        auth_header_value: &str,
+        song_id: &str,
+        song: entity::Song,
+    ) -> Box<dyn warp::Reply> {
+        let token: String = match auth::extract_auth_token(&auth_header_value) {
+            Ok(token) => token,
+            Err(reply) => return reply,
+        };
+
+        let update_song_result = self.usecase.update_song(&token, song_id, song).await;
+
+        match update_song_result {
+            Ok(song) => Box::new(warp::reply::json(&song)),
+            Err(err) => map_usecase_errors(err),
+        }
+    }
 }
 
 fn map_usecase_errors(err: usecase::Error) -> Box<dyn warp::Reply> {
     let status_code = match err {
         usecase::Error::VerificationError { .. } => http::StatusCode::UNAUTHORIZED,
-        usecase::Error::ExistingSongError | usecase::Error::WrongOwnerError => {
-            http::StatusCode::BAD_REQUEST
-        }
+        usecase::Error::ExistingSongError
+        | usecase::Error::WrongOwnerError
+        | usecase::Error::WrongIDError { .. } => http::StatusCode::BAD_REQUEST,
         usecase::Error::NotFoundError { .. } => http::StatusCode::NOT_FOUND,
         usecase::Error::DatastoreError { .. } => http::StatusCode::INTERNAL_SERVER_ERROR,
     };


### PR DESCRIPTION
Implementing update song - functionally very similar to create song, but serves from the /songs/id route (as per REST) and will only update the datastore if a song of that ID already exists.