### PR TITLE
Getting all songs for users

### DIFF
--- a/src/application/songs/dynamodb.rs
+++ b/src/application/songs/dynamodb.rs
@@ -1,10 +1,13 @@
 use super::entity;
-use rusoto_dynamodb::{AttributeValue, DynamoDb, GetItemInput};
+use rusoto_dynamodb::{AttributeValue, DynamoDb, GetItemInput, QueryInput};
+use serde::Deserialize;
 use snafu::Snafu;
 use std::collections::HashMap;
 
 const TABLE_NAME: &str = "Songs";
+const OWNER_INDEX: &str = "owner-index";
 const ID_FIELD: &str = "id";
+const OWNER_FIELD: &str = "owner";
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -41,17 +44,7 @@ impl DynamoDB {
             return Err(Error::NotFoundError);
         }
 
-        let key = {
-            let mut map: HashMap<String, AttributeValue> = HashMap::new();
-            map.insert(
-                ID_FIELD.to_string(),
-                AttributeValue {
-                    s: Some(id.to_string()),
-                    ..Default::default()
-                },
-            );
-            map
-        };
+        let key = make_dynamodb_expression(ID_FIELD, id);
 
         let get_result = self
             .db_client
@@ -64,7 +57,7 @@ impl DynamoDB {
             .await;
 
         match get_result {
-            Ok(output) => song_from_attributes(output.item),
+            Ok(output) => deserialize_from_maybe_attributes(output.item),
             Err(rusoto_err) => {
                 if let rusoto_core::RusotoError::Service(err) = &rusoto_err {
                     if let rusoto_dynamodb::GetItemError::ResourceNotFound(_) = err {
@@ -77,6 +70,44 @@ impl DynamoDB {
                     source: Box::new(rusoto_err),
                 })
             }
+        }
+    }
+
+    pub async fn get_song_summaries_for_owner_id(
+        &self,
+        owner_id: &str,
+    ) -> Result<Vec<entity::SongSummary>, Error> {
+        if owner_id.is_empty() {
+            return Err(Error::NotFoundError);
+        }
+
+        const OWNER_FIELD_VAR_NAME: &str = "#owner";
+        const OWNER_FIELD_VAR_VALUE: &str = ":owner";
+
+        let owner_expression = make_dynamodb_expression(OWNER_FIELD_VAR_VALUE, owner_id);
+        let owner_name = make_hashmap(OWNER_FIELD_VAR_NAME.to_string(), OWNER_FIELD.to_string());
+
+        let query_result = self
+            .db_client
+            .query(QueryInput {
+                table_name: TABLE_NAME.to_string(),
+                index_name: Some(OWNER_INDEX.to_string()),
+                key_condition_expression: Some(format!(
+                    "{} = {}",
+                    OWNER_FIELD_VAR_NAME, OWNER_FIELD_VAR_VALUE
+                )),
+                expression_attribute_names: Some(owner_name),
+                expression_attribute_values: Some(owner_expression),
+                ..Default::default()
+            })
+            .await;
+
+        match query_result {
+            Ok(output) => deserialize_from_maybe_list_attributes(output.items),
+            Err(err) => Err(Error::GenericDynamoError {
+                detail: "Failed to query all songs from data store".to_string(),
+                source: Box::new(err),
+            }),
         }
     }
 
@@ -103,7 +134,7 @@ impl DynamoDB {
     }
 
     pub async fn update_song(&self, song: &entity::Song) -> Result<(), Error> {
-        if song.id.is_empty() {
+        if song.is_new() {
             return Err(Error::NotFoundError);
         }
 
@@ -132,11 +163,47 @@ fn dynamodb_item_from_song(song: &entity::Song) -> Result<HashMap<String, Attrib
     serde_dynamodb::to_hashmap(&song).map_err(|err| Error::SongSerializationError { source: err })
 }
 
-fn song_from_attributes(
+fn deserialize_from_maybe_list_attributes<'a, T: Deserialize<'a>>(
+    output: Option<Vec<HashMap<String, AttributeValue>>>,
+) -> Result<Vec<T>, Error> {
+    let maps = output.ok_or(Error::NotFoundError)?;
+    let mut list: Vec<T> = vec![];
+
+    for attribute in maps {
+        let song: T = deserialize_from_attributes(attribute)?;
+        list.push(song);
+    }
+
+    Ok(list)
+}
+
+fn deserialize_from_maybe_attributes<'a, T: Deserialize<'a>>(
     output: Option<HashMap<String, AttributeValue>>,
-) -> Result<entity::Song, Error> {
+) -> Result<T, Error> {
     let map = output.ok_or(Error::NotFoundError)?;
-    let song: entity::Song = serde_dynamodb::from_hashmap(map)
+    deserialize_from_attributes(map)
+}
+
+fn deserialize_from_attributes<'a, T: Deserialize<'a>>(
+    map: HashMap<String, AttributeValue>,
+) -> Result<T, Error> {
+    let object: T = serde_dynamodb::from_hashmap(map)
         .map_err(|err| Error::MalformedDataError { source: err })?;
-    Ok(song)
+    Ok(object)
+}
+
+fn make_dynamodb_expression(key: &str, value: &str) -> HashMap<String, AttributeValue> {
+    make_hashmap(
+        key.to_string(),
+        AttributeValue {
+            s: Some(value.to_string()),
+            ..Default::default()
+        },
+    )
+}
+
+fn make_hashmap<T>(key: String, value: T) -> HashMap<String, T> {
+    let mut map: HashMap<String, T> = HashMap::new();
+    map.insert(key, value);
+    map
 }

--- a/src/application/songs/entity.rs
+++ b/src/application/songs/entity.rs
@@ -6,17 +6,23 @@ use serde::{Deserialize, Serialize};
 // as opposed to if the struct was thoroughly typed
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Song {
-    pub id: String,
-    pub owner: String,
+    #[serde(flatten)]
+    pub summary: SongSummary,
     elements: Vec<serde_json::Value>,
-    metadata: serde_json::Map<String, serde_json::Value>,
     #[serde(flatten)]
     extra: serde_json::Map<String, serde_json::Value>,
 }
 
+#[derive(Serialize, Deserialize, Debug)]
+pub struct SongSummary {
+    pub id: String,
+    pub owner: String,
+    metadata: serde_json::Map<String, serde_json::Value>,
+}
+
 impl Song {
     pub fn is_new(&self) -> bool {
-        self.id.is_empty()
+        self.summary.id.is_empty()
     }
 
     pub fn create_id(&mut self) {
@@ -24,6 +30,6 @@ impl Song {
             panic!("Cannot assign an ID to a song that already has one")
         }
 
-        self.id = uuid::Uuid::new_v4().to_string()
+        self.summary.id = uuid::Uuid::new_v4().to_string();
     }
 }

--- a/src/application/songs/gateway.rs
+++ b/src/application/songs/gateway.rs
@@ -61,7 +61,7 @@ impl Gateway {
 
 fn map_usecase_errors(err: usecase::Error) -> Box<dyn warp::Reply> {
     let status_code = match err {
-        usecase::Error::VerificationError { .. } => http::StatusCode::UNAUTHORIZED,
+        usecase::Error::GoogleVerificationError { .. } => http::StatusCode::UNAUTHORIZED,
         usecase::Error::ExistingSongError
         | usecase::Error::WrongOwnerError
         | usecase::Error::WrongIDError { .. } => http::StatusCode::BAD_REQUEST,

--- a/src/application/users/usecase.rs
+++ b/src/application/users/usecase.rs
@@ -1,45 +1,82 @@
-use super::super::concerns::google_verification;
 use super::dynamodb;
 use super::entity;
+use crate::application::concerns::google_verification;
+use crate::application::songs;
+
 use snafu::Snafu;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
     #[snafu(display("Failed Google token verification: {}", source))]
-    VerificationError { source: google_signin::Error },
+    GoogleVerificationError { source: google_signin::Error },
+
+    #[snafu(display("This authenticated user cannot access this user's resources"))]
+    OwnerVerificationError,
 
     #[snafu(display("Data store failed: {}", source))]
-    DatastoreError { source: dynamodb::Error },
+    DatastoreError { source: Box<dyn std::error::Error> },
 }
 
 #[derive(Clone)]
 pub struct Usecase {
     google_verification: google_verification::GoogleVerification,
-    datastore: dynamodb::DynamoDB,
+    users_datastore: dynamodb::DynamoDB,
+    songs_datastore: songs::dynamodb::DynamoDB,
 }
 
 impl Usecase {
     pub fn new(
         google_verification: google_verification::GoogleVerification,
-        user_datastore: dynamodb::DynamoDB,
+        users_datastore: dynamodb::DynamoDB,
+        songs_datastore: songs::dynamodb::DynamoDB,
     ) -> Usecase {
         Usecase {
             google_verification,
-            datastore: user_datastore,
+            users_datastore,
+            songs_datastore,
         }
     }
 
-    pub async fn login(&self, user_id_token: &str) -> Result<entity::User, Error> {
-        let input_user = self
-            .google_verification
-            .verify(user_id_token)
-            .map_err(|err| Error::VerificationError { source: err })?;
+    pub async fn login(&self, google_id_token: &str) -> Result<entity::User, Error> {
+        let input_user = self.verify_user(google_id_token)?;
 
-        let output_user_result = self.datastore.ensure_user(&input_user).await;
+        let output_user_result = self.users_datastore.ensure_user(&input_user).await;
 
         match output_user_result {
             Ok(output_user) => Ok(output_user),
-            Err(err) => Err(Error::DatastoreError { source: err }),
+            Err(err) => Err(Error::DatastoreError {
+                source: Box::new(err),
+            }),
         }
+    }
+
+    pub async fn songs_for_user(
+        &self,
+        google_id_token: &str,
+        owner_id: &str,
+    ) -> Result<Vec<songs::entity::SongSummary>, Error> {
+        let user = self.verify_user(google_id_token)?;
+
+        if user.id != owner_id {
+            return Err(Error::OwnerVerificationError);
+        }
+
+        let songs_result = self
+            .songs_datastore
+            .get_song_summaries_for_owner_id(&user.id)
+            .await;
+
+        match songs_result {
+            Ok(songs_list) => Ok(songs_list),
+            Err(err) => Err(Error::DatastoreError {
+                source: Box::new(err),
+            }),
+        }
+    }
+
+    fn verify_user(&self, google_id_token: &str) -> Result<entity::User, Error> {
+        self.google_verification
+            .verify(google_id_token)
+            .map_err(|err| Error::GoogleVerificationError { source: err })
     }
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -2,5 +2,5 @@ pub use serve::serve;
 
 mod cors;
 mod serve;
-mod songs;
+pub mod songs;
 mod users;

--- a/src/server/users.rs
+++ b/src/server/users.rs
@@ -1,28 +1,37 @@
 use super::cors;
 use crate::application::concerns;
+use crate::application::songs;
 use crate::application::users;
+
 use crate::db_utils::dynamodb::db_client;
 use warp::Filter;
 
 pub fn users_server() -> warp::filters::BoxedFilter<(impl warp::reply::Reply,)> {
-    let users_gateway = create_users_gateway();
-
-    let with_users_gateway = warp::any().map(move || users_gateway.clone());
-
-    warp::post()
-        .and(with_users_gateway)
-        .and(warp::path!("login"))
+    let login_path = warp::post()
+        .and(with_users_gateway())
         .and(warp::header::<String>("authorization"))
+        .and(warp::path!("login"))
         .and_then(login)
-        .with(cors::cors_filter(vec!["POST"]))
-        .boxed()
+        .with(cors::cors_filter(vec!["POST"]));
+
+    let songs_for_user = warp::get()
+        .and(with_users_gateway())
+        .and(warp::header::<String>("authorization"))
+        .and(warp::path!("users" / String / "songs"))
+        .and_then(songs_for_user)
+        .with(cors::cors_filter(vec!["GET"]));
+
+    login_path.or(songs_for_user).boxed()
 }
 
-fn create_users_gateway() -> users::gateway::Gateway {
-    let datastore = users::dynamodb::DynamoDB::new(db_client());
+fn with_users_gateway() -> warp::filters::BoxedFilter<(users::gateway::Gateway,)> {
+    let users_datastore = users::dynamodb::DynamoDB::new(db_client());
+    let songs_datastore = songs::dynamodb::DynamoDB::new(db_client());
     let verification = concerns::google_verification::GoogleVerification::new();
-    let usecase = users::usecase::Usecase::new(verification, datastore);
-    users::gateway::Gateway::new(usecase)
+    let usecase = users::usecase::Usecase::new(verification, users_datastore, songs_datastore);
+    let gateway = users::gateway::Gateway::new(usecase);
+
+    warp::any().map(move || gateway.clone()).boxed()
 }
 
 async fn login(
@@ -30,4 +39,12 @@ async fn login(
     auth_value: String,
 ) -> Result<Box<dyn warp::Reply>, warp::Rejection> {
     Ok(users_gateway.login(&auth_value).await)
+}
+
+async fn songs_for_user(
+    users_gateway: users::gateway::Gateway,
+    auth_value: String,
+    user_id: String,
+) -> Result<Box<dyn warp::Reply>, warp::Rejection> {
+    Ok(users_gateway.songs_for_user(&auth_value, &user_id).await)
 }


### PR DESCRIPTION
Allow collecting all songs for users and returning them - i.e. the catalog of songs that this user has worked on.

They are returned in the form of summary - all the metadata about the song but none of its actual contents (chords/lyrics), to encourage fetching of the song fresh and not caching the song for a cleaner paradigm.