### PR TITLE
Protect against song overwriting

### DIFF
--- a/src/application/songs/gateway.rs
+++ b/src/application/songs/gateway.rs
@@ -63,6 +63,7 @@ fn map_usecase_errors(err: usecase::Error) -> Box<dyn warp::Reply> {
     let status_code = match err {
         usecase::Error::GoogleVerificationError { .. } => http::StatusCode::UNAUTHORIZED,
         usecase::Error::ExistingSongError
+        | usecase::Error::OverwriteError
         | usecase::Error::WrongOwnerError
         | usecase::Error::WrongIDError { .. } => http::StatusCode::BAD_REQUEST,
         usecase::Error::NotFoundError { .. } => http::StatusCode::NOT_FOUND,


### PR DESCRIPTION
C/P'd from the comments:

                // prevent overwriting a more recent save if the last saved at timestamp is greater than the current one
                // example:
                // A --> B
                //   \----->C
                //
                // Suppose I open the song at time A on two computers, make edits on both somewhat absentmindedly
                // I first save at time B - the payload for the song for the last saved at would be A
                // presume this succeeds, the server copy is now from time B and its last saved at time is also B
                //
                // Now I save another copy at time C, but the predecessor of my copy at time C was from A
                // If I just go with last write wins, then all changes from the copy at time B would be overwritten
                // So by comparing the timestamp at the save at C (A vs B), the save will fail to protect overwriting data.
                //
                // The user can then refetch the copy at time B and copy over their changes from time C (manual merge)
                // and form a copy that will be accepted by the server:
                //
                // A --> B----->B+C
                //   \----->C---/