### PR TITLE
Fix overwriting usecase time gating

### DIFF
--- a/src/application/songs/entity.rs
+++ b/src/application/songs/entity.rs
@@ -1,3 +1,4 @@
+use chrono::Timelike;
 use serde::{Deserialize, Serialize};
 
 // this struct is entirely structured around the JSON representation being the canonical
@@ -36,6 +37,10 @@ impl Song {
     }
 
     pub fn set_saved_time(&mut self) {
-        self.summary.last_saved_at = Some(chrono::Utc::now());
+        // truncate nanoseconds because this will be consumed by the browser
+        // and browser dates have only millisecond resolution
+        //
+        // this will result in only second level resolution but will minimize confusion
+        self.summary.last_saved_at = chrono::Utc::now().with_nanosecond(0);
     }
 }

--- a/src/application/songs/usecase.rs
+++ b/src/application/songs/usecase.rs
@@ -158,10 +158,6 @@ impl Usecase {
                 // A --> B----->B+C
                 //   \----->C---/
                 if curr_last_saved_at.gt(&next_last_saved_at) {
-                    log::info!("Overwriting error encountered");
-                    log::info!("Current saved at: {}", curr_last_saved_at.to_rfc3339());
-                    log::info!("Next saved at: {}", next_last_saved_at.to_rfc3339());
-
                     return Err(Error::OverwriteError);
                 }
             }


### PR DESCRIPTION
When time is captured in the rust server, it's captured to the nanosecond level - however when it's sent to the browser, the browser only captures it to the millisecond level.

So when the browser roundtrip sends the data back to the server, the time now looks like it's (albeit tiny bit) before the time that was sent.

This change truncates the time resolution so that all involved components have an accurate (but imprecise) understanding of what time is.