### PR TITLE
Structured client errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,6 +192,7 @@ dependencies = [
  "serde_json",
  "snafu",
  "tokio",
+ "typetag",
  "uuid",
  "warp",
 ]
@@ -284,6 +285,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fbaabec2c953050352311293be5c6aba8e141ba19d6811862b232d6fd020484"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "digest"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -351,6 +362,15 @@ dependencies = [
  "log 0.4.11",
  "regex",
  "termcolor",
+]
+
+[[package]]
+name = "erased-serde"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ca8b296792113e1500fd935ae487be6e00ce318952a6880555554824d6ebf38"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -525,6 +545,17 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "ghost"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a5bcf1bbeab73aa4cf2fde60a846858dc036163c7c33bec309f8d17de785479"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -764,6 +795,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19a8a95243d5a0398cae618ec29477c6e3cb631152be5c19481f80bc71559754"
 dependencies = [
  "bytes",
+]
+
+[[package]]
+name = "inventory"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fedd49de24d8c263613701406611410687148ae8c37cd6452650b250f753a0dd"
+dependencies = [
+ "ctor",
+ "ghost",
+ "inventory-impl",
+]
+
+[[package]]
+name = "inventory-impl"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddead8880bc50f57fcd3b5869a7f6ff92570bb4e8f6870c22e2483272f2256da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2047,6 +2100,30 @@ name = "typenum"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
+
+[[package]]
+name = "typetag"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83b97b107d25d29de6879ac4f676ac5bfea92bdd01f206e995794493f1fc2e32"
+dependencies = [
+ "erased-serde",
+ "inventory",
+ "lazy_static",
+ "serde",
+ "typetag-impl",
+]
+
+[[package]]
+name = "typetag-impl"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f2466fc87b07b800a5060f89ba579d6882f7a03ac21363e4737764aaf9f99f9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "unicase"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,4 @@ snafu = "*"
 uuid = { version = "*", features = ["v4", "serde"] }
 chrono = "*"
 log = "0.4.11"
+typetag = "*"

--- a/src/application/concerns/gateway/errors.rs
+++ b/src/application/concerns/gateway/errors.rs
@@ -7,7 +7,21 @@ pub trait GatewayError {
 }
 
 pub fn error_reply(error: Box<dyn GatewayError>) -> Box<dyn warp::Reply> {
-    let json = Box::new(warp::reply::json(&error));
+    let mut value: serde_json::Value = match serde_json::to_value(&error) {
+        Ok(value) => value,
+        Err(err) => panic!("Gateway Error should be serializable!: {}", err),
+    };
+
+    let serde_object = match value.as_object_mut() {
+        Some(object) => {
+            // removing the type field, typetag doesn't expose an option to leave it untagged
+            object.remove("type");
+            object
+        }
+        None => panic!("Unexpected, serialized GatewayError cannot be made into a Hashmap"),
+    };
+
+    let json = Box::new(warp::reply::json(serde_object));
     Box::new(warp::reply::with_status(json, error.status_code()))
 }
 

--- a/src/application/concerns/gateway/errors.rs
+++ b/src/application/concerns/gateway/errors.rs
@@ -1,0 +1,85 @@
+use http::StatusCode;
+use serde::{Deserialize, Serialize};
+
+#[typetag::serde(tag = "type")]
+pub trait GatewayError {
+    fn status_code(&self) -> http::StatusCode;
+}
+
+pub fn error_reply(error: Box<dyn GatewayError>) -> Box<dyn warp::Reply> {
+    let json = Box::new(warp::reply::json(&error));
+    Box::new(warp::reply::with_status(json, error.status_code()))
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(tag = "code")]
+#[serde(rename_all = "snake_case")]
+pub enum BadRequestError {
+    CreateSongExists { msg: String },
+    UpdateSongOverwrite { msg: String },
+}
+
+#[typetag::serde]
+impl GatewayError for BadRequestError {
+    fn status_code(&self) -> StatusCode {
+        http::StatusCode::BAD_REQUEST
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(tag = "code")]
+#[serde(rename_all = "snake_case")]
+pub enum NotFoundError {
+    SongNotFound { msg: String },
+}
+
+#[typetag::serde]
+impl GatewayError for NotFoundError {
+    fn status_code(&self) -> StatusCode {
+        http::StatusCode::NOT_FOUND
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(tag = "code")]
+#[serde(rename_all = "snake_case")]
+pub enum UnauthorizedError {
+    FailedGoogleVerification { msg: String },
+}
+
+#[typetag::serde]
+impl GatewayError for UnauthorizedError {
+    fn status_code(&self) -> StatusCode {
+        http::StatusCode::UNAUTHORIZED
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(tag = "code")]
+#[serde(rename_all = "snake_case")]
+pub enum ForbiddenError {
+    GetSongsForUserNotAllowed { msg: String },
+    UpdateSongOwnerNotAllowed { msg: String },
+    UpdateSongWrongID { msg: String },
+}
+
+#[typetag::serde]
+impl GatewayError for ForbiddenError {
+    fn status_code(&self) -> StatusCode {
+        http::StatusCode::FORBIDDEN
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(tag = "code")]
+#[serde(rename_all = "snake_case")]
+pub enum InternalServerError {
+    DatastoreError { msg: String },
+}
+
+#[typetag::serde]
+impl GatewayError for InternalServerError {
+    fn status_code(&self) -> StatusCode {
+        http::StatusCode::INTERNAL_SERVER_ERROR
+    }
+}

--- a/src/application/concerns/gateway/mod.rs
+++ b/src/application/concerns/gateway/mod.rs
@@ -1,1 +1,2 @@
 pub mod auth;
+pub mod errors;


### PR DESCRIPTION
Return all errors in the format of

{
msg: string,
code: string,
}

the important part being the code - for the same code the client can always handle it the same way, where as the msg returns a more human readable component