### PR TITLE
Log more error details for RabbitMQ publish error

### DIFF
--- a/src/application/songs/tracks/usecase.rs
+++ b/src/application/songs/tracks/usecase.rs
@@ -141,8 +141,8 @@ impl Usecase {
 
         match publish_result {
             Ok(_) => Ok(()),
-            Err(_) => Err(Error::PublishError {
-                msg: "Failed to publish message to RabbitMQ".to_string(),
+            Err(err) => Err(Error::PublishError {
+                msg: format!("Failed to publish message to RabbitMQ: {}", err),
             }),
         }
     }


### PR DESCRIPTION
Adding some more detailed logging for errors that happen when publishing messages fail. This happens randomly and we need a bit more understanding around why.