### PR TITLE
Restore running verify build for all PR builds

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,11 +1,6 @@
 name: PR Build
 
-on:
-  pull_request:
-    paths:
-      - 'src/**'
-      - 'Cargo.toml'
-      - 'Cargo.lock'
+on: [pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
Unscoping the verify build. It seems that the master compile check gate must be something that runs all the time and can't be conditional, so this must always be running, even if sometimes unnecessarily.