### PR TITLE
Swap development ports

### DIFF
--- a/go-rewrite/src/server.go
+++ b/go-rewrite/src/server.go
@@ -14,23 +14,6 @@ func main() {
 		panic("Legacy backend host env var is not set")
 	}
 
-	runningEnvironment, isSet := os.LookupEnv("ENVIRONMENT")
-	if !isSet {
-		panic("Environment is not set")
-	}
-
-	portAddr := ""
-
-	switch runningEnvironment {
-	case "production":
-		portAddr = ":5000"
-	case "development":
-		portAddr = ":5001"
-	default:
-		panicMsg := "Unrecognized environment: " + runningEnvironment
-		panic(panicMsg)
-	}
-
 	legacyHostURL, err := url.Parse(legacyHostStr)
 	if err != nil {
 		panic(err)
@@ -54,5 +37,5 @@ func main() {
 		},
 	}))
 
-	e.Logger.Fatal(e.Start(portAddr))
+	e.Logger.Fatal(e.Start(":5000"))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,5 +8,10 @@ mod server;
 async fn main() {
     pretty_env_logger::init();
 
-    server::serve(([0, 0, 0, 0], 5000)).await;
+    let port = match environment::get_environment() {
+        environment::Environment::Development => 5001,
+        environment::Environment::Production => 5000,
+    };
+    
+    server::serve(([0, 0, 0, 0], port)).await;
 }


### PR DESCRIPTION
Before this, in development, Rust server runs on 5000 and Go server runs on 5001. Swapping it to be such that Rust runs on 5001 and Go runs on 5000, so that the Go server is the "default" thing to point to.