### PR TITLE
Local env: changes to dynamo region

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,10 @@ start-db:
 	make restore-db
 
 backup-db:
-	python ./scripts/dynamodump.py -m backup -r local -s "*" --host localhost --port 8000 --accessKey local --secretKey local --dumpPath ./db_dump
+	python3 ./scripts/dynamodump.py -m backup -s "*" --host localhost --port 8000 --accessKey local --secretKey local --region local --dumpPath ./db_dump
 
 backup-production:
-	python ./scripts/dynamodump.py -m backup -r us-east-2 -s "*" --accessKey ${ACCESS_KEY_ID} --secretKey ${SECRET_ACCESS_KEY} --dumpPath ./db_dump
+	python3 ./scripts/dynamodump.py -m backup -r us-east-2 -s "*" --accessKey ${PRODUCTION_AWS_ACCESS_KEY_ID} --secretKey ${PRODUCTION_AWS_SECRET_ACCESS_KEY} --dumpPath ./db_dump
 
 restore-db:
-	python ./scripts/dynamodump.py -m restore -r local -s "*" --host localhost --port 8000 --accessKey local --secretKey local --dumpPath ./db_dump
+	python3 ./scripts/dynamodump.py -m restore -s "*" --host localhost --port 8000 --accessKey local --secretKey local --region local --dumpPath ./db_dump

--- a/db_dump/Songs/data/0001.json
+++ b/db_dump/Songs/data/0001.json
@@ -1,5 +1,5 @@
 {
-  "Count": 52,
+  "Count": 58,
   "Items": [
     {
       "metadata": {
@@ -63,11 +63,11 @@
           "title": {
             "S": "\u82fa"
           },
-          "performedBy": {
-            "S": "yonawo"
-          },
           "composedBy": {
             "S": "\u8352\u8c37\u7fd4\u5927"
+          },
+          "performedBy": {
+            "S": "yonawo"
           }
         }
       },
@@ -75,7 +75,7 @@
         "S": "114135225559751053856"
       },
       "lastSavedAt": {
-        "S": "2022-04-02T05:52:33Z"
+        "S": "2022-05-07T05:00:10Z"
       },
       "id": {
         "S": "ffac9588-f18b-40fe-bbc8-fa3e5937c1db"
@@ -89,11 +89,11 @@
               },
               "section": {
                 "M": {
-                  "name": {
-                    "S": "Intro"
-                  },
                   "type": {
                     "S": "time"
+                  },
+                  "name": {
+                    "S": "Intro"
                   },
                   "time": {
                     "N": "0"
@@ -104,6 +104,113 @@
                 "L": [
                   {
                     "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Em9"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue400"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue400"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Am7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue400"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "D7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Ebdim"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
                       "chord": {
                         "S": "Em9"
                       },
@@ -183,118 +290,11 @@
                   },
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "Ebdim"
                       },
-                      "lyric": {
-                        "M": {
-                          "serializedLyric": {
-                            "S": "\ue200"
-                          }
-                        }
-                      }
-                    }
-                  }
-                ]
-              }
-            }
-          },
-          {
-            "M": {
-              "type": {
-                "S": "ChordLine"
-              },
-              "elements": {
-                "L": [
-                  {
-                    "M": {
-                      "chord": {
-                        "S": "Em9"
-                      },
                       "type": {
                         "S": "ChordBlock"
-                      },
-                      "lyric": {
-                        "M": {
-                          "serializedLyric": {
-                            "S": "\ue400"
-                          }
-                        }
-                      }
-                    }
-                  },
-                  {
-                    "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
-                      "chord": {
-                        "S": "Bm7"
-                      },
-                      "lyric": {
-                        "M": {
-                          "serializedLyric": {
-                            "S": "\ue400"
-                          }
-                        }
-                      }
-                    }
-                  }
-                ]
-              }
-            }
-          },
-          {
-            "M": {
-              "type": {
-                "S": "ChordLine"
-              },
-              "elements": {
-                "L": [
-                  {
-                    "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
-                      "chord": {
-                        "S": "Am7"
-                      },
-                      "lyric": {
-                        "M": {
-                          "serializedLyric": {
-                            "S": "\ue400"
-                          }
-                        }
-                      }
-                    }
-                  },
-                  {
-                    "M": {
-                      "chord": {
-                        "S": "D7"
-                      },
-                      "type": {
-                        "S": "ChordBlock"
-                      },
-                      "lyric": {
-                        "M": {
-                          "serializedLyric": {
-                            "S": "\ue200"
-                          }
-                        }
-                      }
-                    }
-                  },
-                  {
-                    "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
-                      "chord": {
-                        "S": "Ebdim"
                       },
                       "lyric": {
                         "M": {
@@ -316,11 +316,11 @@
               },
               "section": {
                 "M": {
-                  "type": {
-                    "S": "time"
-                  },
                   "name": {
                     "S": "Verse"
+                  },
+                  "type": {
+                    "S": "time"
                   },
                   "time": {
                     "N": "24"
@@ -348,11 +348,11 @@
                   },
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "Bm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -376,11 +376,11 @@
                 "L": [
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "Am7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -410,11 +410,11 @@
                   },
                   {
                     "M": {
-                      "chord": {
-                        "S": "Ebdim"
-                      },
                       "type": {
                         "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Ebdim"
                       },
                       "lyric": {
                         "M": {
@@ -438,11 +438,11 @@
                 "L": [
                   {
                     "M": {
-                      "chord": {
-                        "S": "Em9"
-                      },
                       "type": {
                         "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Em9"
                       },
                       "lyric": {
                         "M": {
@@ -466,11 +466,11 @@
                 "L": [
                   {
                     "M": {
-                      "chord": {
-                        "S": "Bm7"
-                      },
                       "type": {
                         "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Bm7"
                       },
                       "lyric": {
                         "M": {
@@ -483,11 +483,11 @@
                   },
                   {
                     "M": {
-                      "chord": {
-                        "S": "Am7"
-                      },
                       "type": {
                         "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Am7"
                       },
                       "lyric": {
                         "M": {
@@ -528,11 +528,11 @@
                   },
                   {
                     "M": {
-                      "chord": {
-                        "S": "Ebdim"
-                      },
                       "type": {
                         "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Ebdim"
                       },
                       "lyric": {
                         "M": {
@@ -554,11 +554,11 @@
               },
               "section": {
                 "M": {
-                  "name": {
-                    "S": "Verse"
-                  },
                   "type": {
                     "S": "time"
+                  },
+                  "name": {
+                    "S": "Verse"
                   },
                   "time": {
                     "N": "46"
@@ -569,11 +569,11 @@
                 "L": [
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "Em9"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -631,11 +631,11 @@
                   },
                   {
                     "M": {
-                      "chord": {
-                        "S": "D7"
-                      },
                       "type": {
                         "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "D7"
                       },
                       "lyric": {
                         "M": {
@@ -648,11 +648,11 @@
                   },
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "Ebdim"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -676,11 +676,11 @@
                 "L": [
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "Em9"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -704,11 +704,11 @@
                 "L": [
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "Bm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -721,11 +721,11 @@
                   },
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "Am7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -749,11 +749,11 @@
                 "L": [
                   {
                     "M": {
-                      "chord": {
-                        "S": "D7"
-                      },
                       "type": {
                         "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "D7"
                       },
                       "lyric": {
                         "M": {
@@ -766,11 +766,11 @@
                   },
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "Ebdim"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -794,11 +794,11 @@
                 "L": [
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "Em9"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -811,11 +811,11 @@
                   },
                   {
                     "M": {
-                      "chord": {
-                        "S": "Bm7"
-                      },
                       "type": {
                         "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Bm7"
                       },
                       "lyric": {
                         "M": {
@@ -839,11 +839,11 @@
                 "L": [
                   {
                     "M": {
-                      "chord": {
-                        "S": "Am7"
-                      },
                       "type": {
                         "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Am7"
                       },
                       "lyric": {
                         "M": {
@@ -873,11 +873,11 @@
                   },
                   {
                     "M": {
-                      "chord": {
-                        "S": "Ebdim"
-                      },
                       "type": {
                         "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Ebdim"
                       },
                       "lyric": {
                         "M": {
@@ -899,11 +899,11 @@
               },
               "section": {
                 "M": {
-                  "type": {
-                    "S": "time"
-                  },
                   "name": {
                     "S": "Prechorus"
+                  },
+                  "type": {
+                    "S": "time"
                   },
                   "time": {
                     "N": "77"
@@ -914,16 +914,33 @@
                 "L": [
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
                           "serializedLyric": {
-                            "S": "ashita ga sunnari "
+                            "S": "ashita ga "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "C^"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "sunnari "
                           }
                         }
                       }
@@ -942,11 +959,11 @@
                 "L": [
                   {
                     "M": {
+                      "chord": {
+                        "S": "B7"
+                      },
                       "type": {
                         "S": "ChordBlock"
-                      },
-                      "chord": {
-                        "S": ""
                       },
                       "lyric": {
                         "M": {
@@ -970,6 +987,68 @@
                 "L": [
                   {
                     "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "sou ni naru no yobi-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Em9"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "tomete"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Dm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
                       "type": {
                         "S": "ChordBlock"
                       },
@@ -979,7 +1058,41 @@
                       "lyric": {
                         "M": {
                           "serializedLyric": {
-                            "S": "sou ni naru no yobitomete"
+                            "S": "kimi nara "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "C^"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "unzari "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "B7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "shiteru darou kedo"
                           }
                         }
                       }
@@ -1007,35 +1120,41 @@
                       "lyric": {
                         "M": {
                           "serializedLyric": {
-                            "S": "kimi nara unzari shiteru darou kedo"
+                            "S": "douka kono koe ni "
                           }
                         }
                       }
                     }
-                  }
-                ]
-              }
-            }
-          },
-          {
-            "M": {
-              "type": {
-                "S": "ChordLine"
-              },
-              "elements": {
-                "L": [
+                  },
                   {
                     "M": {
+                      "chord": {
+                        "S": "Em9"
+                      },
                       "type": {
                         "S": "ChordBlock"
-                      },
-                      "chord": {
-                        "S": ""
                       },
                       "lyric": {
                         "M": {
                           "serializedLyric": {
-                            "S": "douka kono koe ni mimi o kashite"
+                            "S": "mimi o kashi-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Dm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "te"
                           }
                         }
                       }
@@ -1067,11 +1186,11 @@
                 "L": [
                   {
                     "M": {
-                      "chord": {
-                        "S": "C^"
-                      },
                       "type": {
                         "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "C^"
                       },
                       "lyric": {
                         "M": {
@@ -1085,7 +1204,7 @@
                   {
                     "M": {
                       "chord": {
-                        "S": "Bm7"
+                        "S": "B7"
                       },
                       "type": {
                         "S": "ChordBlock"
@@ -1129,11 +1248,11 @@
                   },
                   {
                     "M": {
-                      "chord": {
-                        "S": "D7"
-                      },
                       "type": {
                         "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "D7"
                       },
                       "lyric": {
                         "M": {
@@ -1150,12 +1269,29 @@
                         "S": "ChordBlock"
                       },
                       "chord": {
-                        "S": "G7"
+                        "S": "G^"
                       },
                       "lyric": {
                         "M": {
                           "serializedLyric": {
-                            "S": "ushinaisou"
+                            "S": "ushinaiso-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "G7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "u"
                           }
                         }
                       }
@@ -1174,11 +1310,11 @@
                 "L": [
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "C^"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -1236,11 +1372,11 @@
                   },
                   {
                     "M": {
-                      "chord": {
-                        "S": "Am7"
-                      },
                       "type": {
                         "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Am7"
                       },
                       "lyric": {
                         "M": {
@@ -1253,11 +1389,11 @@
                   },
                   {
                     "M": {
-                      "chord": {
-                        "S": "Ab7"
-                      },
                       "type": {
                         "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Ab7"
                       },
                       "lyric": {
                         "M": {
@@ -1270,11 +1406,11 @@
                   },
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "G^"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -1405,11 +1541,11 @@
                 "L": [
                   {
                     "M": {
-                      "chord": {
-                        "S": "Em9"
-                      },
                       "type": {
                         "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Em9"
                       },
                       "lyric": {
                         "M": {
@@ -1422,11 +1558,11 @@
                   },
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "Bm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -1450,11 +1586,11 @@
                 "L": [
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "Am7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -1525,11 +1661,11 @@
                 "L": [
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "Em9"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -1559,11 +1695,11 @@
                   },
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "C^"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -1576,11 +1712,11 @@
                   },
                   {
                     "M": {
-                      "chord": {
-                        "S": "Cm6"
-                      },
                       "type": {
                         "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Cm6"
                       },
                       "lyric": {
                         "M": {
@@ -1604,11 +1740,11 @@
                 "L": [
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -1621,11 +1757,11 @@
                   },
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "Bm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -1683,11 +1819,11 @@
                 "L": [
                   {
                     "M": {
-                      "chord": {
-                        "S": ""
-                      },
                       "type": {
                         "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
                       },
                       "lyric": {
                         "M": {
@@ -1779,11 +1915,11 @@
                 "L": [
                   {
                     "M": {
-                      "chord": {
-                        "S": ""
-                      },
                       "type": {
                         "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
                       },
                       "lyric": {
                         "M": {
@@ -1796,11 +1932,11 @@
                   },
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "Em7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -1841,11 +1977,11 @@
                 "L": [
                   {
                     "M": {
-                      "chord": {
-                        "S": ""
-                      },
                       "type": {
                         "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
                       },
                       "lyric": {
                         "M": {
@@ -1892,11 +2028,11 @@
                   },
                   {
                     "M": {
-                      "chord": {
-                        "S": "Am7"
-                      },
                       "type": {
                         "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Am7"
                       },
                       "lyric": {
                         "M": {
@@ -1950,11 +2086,11 @@
                 "L": [
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "C^"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -1967,11 +2103,11 @@
                   },
                   {
                     "M": {
-                      "chord": {
-                        "S": "Bm7"
-                      },
                       "type": {
                         "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "B7"
                       },
                       "lyric": {
                         "M": {
@@ -1995,11 +2131,11 @@
                 "L": [
                   {
                     "M": {
-                      "chord": {
-                        "S": "Am7"
-                      },
                       "type": {
                         "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Am7"
                       },
                       "lyric": {
                         "M": {
@@ -2012,11 +2148,11 @@
                   },
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "D7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -2033,12 +2169,29 @@
                         "S": "ChordBlock"
                       },
                       "chord": {
+                        "S": "G^"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "ushinaiso-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
                         "S": "G7"
                       },
                       "lyric": {
                         "M": {
                           "serializedLyric": {
-                            "S": "ushinaisou"
+                            "S": "u"
                           }
                         }
                       }
@@ -2057,11 +2210,11 @@
                 "L": [
                   {
                     "M": {
-                      "chord": {
-                        "S": "C^"
-                      },
                       "type": {
                         "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "C^"
                       },
                       "lyric": {
                         "M": {
@@ -2074,11 +2227,11 @@
                   },
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "Bm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -2119,11 +2272,11 @@
                   },
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "Am7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -2136,11 +2289,11 @@
                   },
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "Ab7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -2198,11 +2351,11 @@
                   },
                   {
                     "M": {
-                      "chord": {
-                        "S": "Bm7"
-                      },
                       "type": {
                         "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Bm7"
                       },
                       "lyric": {
                         "M": {
@@ -2243,11 +2396,11 @@
                   },
                   {
                     "M": {
-                      "chord": {
-                        "S": "D7"
-                      },
                       "type": {
                         "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "D7"
                       },
                       "lyric": {
                         "M": {
@@ -2260,12 +2413,12 @@
                   },
                   {
                     "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
                       "chord": {
                         "S": "Ebdim"
                       },
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "lyric": {
                         "M": {
                           "serializedLyric": {
@@ -2288,11 +2441,11 @@
                 "L": [
                   {
                     "M": {
-                      "chord": {
-                        "S": "Em9"
-                      },
                       "type": {
                         "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Em9"
                       },
                       "lyric": {
                         "M": {
@@ -2350,11 +2503,11 @@
                   },
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "D7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -2408,6 +2561,141 @@
                 "L": [
                   {
                     "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "furi-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Em9"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "kaeru toki afureru kanjou mou"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue100ano hi no yoru no ano kandou mo"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Am7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue100ashita ni wa kie-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "D7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "useteku "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Ebdim"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "kanjou"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
                       "chord": {
                         "S": ""
                       },
@@ -2417,7 +2705,69 @@
                       "lyric": {
                         "M": {
                           "serializedLyric": {
-                            "S": "furikaeru toki afureru kanjou"
+                            "S": "goma-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Em9"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "kashita kuchi obieru hyoujou"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "dou-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "jou nara toubun hitsuyou nai yo"
                           }
                         }
                       }
@@ -2440,32 +2790,21 @@
                         "S": "ChordBlock"
                       },
                       "chord": {
-                        "S": ""
+                        "S": "Am7"
                       },
                       "lyric": {
                         "M": {
                           "serializedLyric": {
-                            "S": "mou ano hi no yoru no ano kandou mo"
+                            "S": "ashita no i-"
                           }
                         }
                       }
                     }
-                  }
-                ]
-              }
-            }
-          },
-          {
-            "M": {
-              "type": {
-                "S": "ChordLine"
-              },
-              "elements": {
-                "L": [
+                  },
                   {
                     "M": {
                       "chord": {
-                        "S": ""
+                        "S": "D7"
                       },
                       "type": {
                         "S": "ChordBlock"
@@ -2473,27 +2812,16 @@
                       "lyric": {
                         "M": {
                           "serializedLyric": {
-                            "S": "ashita ni wa kieuseteku kanjou"
+                            "S": "ma-"
                           }
                         }
                       }
                     }
-                  }
-                ]
-              }
-            }
-          },
-          {
-            "M": {
-              "type": {
-                "S": "ChordLine"
-              },
-              "elements": {
-                "L": [
+                  },
                   {
                     "M": {
                       "chord": {
-                        "S": ""
+                        "S": "Ebdim"
                       },
                       "type": {
                         "S": "ChordBlock"
@@ -2501,63 +2829,7 @@
                       "lyric": {
                         "M": {
                           "serializedLyric": {
-                            "S": "gomakashita kuchi obieru hyoujou"
-                          }
-                        }
-                      }
-                    }
-                  }
-                ]
-              }
-            }
-          },
-          {
-            "M": {
-              "type": {
-                "S": "ChordLine"
-              },
-              "elements": {
-                "L": [
-                  {
-                    "M": {
-                      "chord": {
-                        "S": ""
-                      },
-                      "type": {
-                        "S": "ChordBlock"
-                      },
-                      "lyric": {
-                        "M": {
-                          "serializedLyric": {
-                            "S": "doujou nara toubun hitsuyou nai yo"
-                          }
-                        }
-                      }
-                    }
-                  }
-                ]
-              }
-            }
-          },
-          {
-            "M": {
-              "type": {
-                "S": "ChordLine"
-              },
-              "elements": {
-                "L": [
-                  {
-                    "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
-                      "chord": {
-                        "S": ""
-                      },
-                      "lyric": {
-                        "M": {
-                          "serializedLyric": {
-                            "S": "ashita no imagoro ni wa"
+                            "S": "goro ni wa"
                           }
                         }
                       }
@@ -2589,11 +2861,11 @@
                 "L": [
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "C^"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -2606,11 +2878,11 @@
                   },
                   {
                     "M": {
-                      "chord": {
-                        "S": "Bm7"
-                      },
                       "type": {
                         "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "B7"
                       },
                       "lyric": {
                         "M": {
@@ -2634,11 +2906,11 @@
                 "L": [
                   {
                     "M": {
-                      "chord": {
-                        "S": "Am7"
-                      },
                       "type": {
                         "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Am7"
                       },
                       "lyric": {
                         "M": {
@@ -2651,16 +2923,33 @@
                   },
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "D7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
                           "serializedLyric": {
                             "S": "wa ikiba "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "G^"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "ushinaiso-"
                           }
                         }
                       }
@@ -2677,7 +2966,7 @@
                       "lyric": {
                         "M": {
                           "serializedLyric": {
-                            "S": "ushinaisou"
+                            "S": "u"
                           }
                         }
                       }
@@ -2696,11 +2985,11 @@
                 "L": [
                   {
                     "M": {
-                      "chord": {
-                        "S": "C^"
-                      },
                       "type": {
                         "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "C^"
                       },
                       "lyric": {
                         "M": {
@@ -2713,11 +3002,11 @@
                   },
                   {
                     "M": {
-                      "chord": {
-                        "S": "Bm7"
-                      },
                       "type": {
                         "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Bm7"
                       },
                       "lyric": {
                         "M": {
@@ -2741,11 +3030,11 @@
                 "L": [
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -2792,11 +3081,11 @@
                   },
                   {
                     "M": {
-                      "chord": {
-                        "S": "G^"
-                      },
                       "type": {
                         "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "G^"
                       },
                       "lyric": {
                         "M": {
@@ -2833,6 +3122,113 @@
                 "L": [
                   {
                     "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Em9"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue400"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue400"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Am7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue400"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "D7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Ebdim"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
                       "chord": {
                         "S": "Em9"
                       },
@@ -2850,11 +3246,118 @@
                   },
                   {
                     "M": {
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue400"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
                       "type": {
                         "S": "ChordBlock"
                       },
                       "chord": {
+                        "S": "Am7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue400"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "D7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Ebdim"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Em9"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue400"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
                         "S": "Bm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -2917,220 +3420,6 @@
                       },
                       "chord": {
                         "S": "Ebdim"
-                      },
-                      "lyric": {
-                        "M": {
-                          "serializedLyric": {
-                            "S": "\ue200"
-                          }
-                        }
-                      }
-                    }
-                  }
-                ]
-              }
-            }
-          },
-          {
-            "M": {
-              "type": {
-                "S": "ChordLine"
-              },
-              "elements": {
-                "L": [
-                  {
-                    "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
-                      "chord": {
-                        "S": "Em9"
-                      },
-                      "lyric": {
-                        "M": {
-                          "serializedLyric": {
-                            "S": "\ue400"
-                          }
-                        }
-                      }
-                    }
-                  },
-                  {
-                    "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
-                      "chord": {
-                        "S": "Bm7"
-                      },
-                      "lyric": {
-                        "M": {
-                          "serializedLyric": {
-                            "S": "\ue400"
-                          }
-                        }
-                      }
-                    }
-                  }
-                ]
-              }
-            }
-          },
-          {
-            "M": {
-              "type": {
-                "S": "ChordLine"
-              },
-              "elements": {
-                "L": [
-                  {
-                    "M": {
-                      "chord": {
-                        "S": "Am7"
-                      },
-                      "type": {
-                        "S": "ChordBlock"
-                      },
-                      "lyric": {
-                        "M": {
-                          "serializedLyric": {
-                            "S": "\ue400"
-                          }
-                        }
-                      }
-                    }
-                  },
-                  {
-                    "M": {
-                      "chord": {
-                        "S": "D7"
-                      },
-                      "type": {
-                        "S": "ChordBlock"
-                      },
-                      "lyric": {
-                        "M": {
-                          "serializedLyric": {
-                            "S": "\ue200"
-                          }
-                        }
-                      }
-                    }
-                  },
-                  {
-                    "M": {
-                      "chord": {
-                        "S": "Ebdim"
-                      },
-                      "type": {
-                        "S": "ChordBlock"
-                      },
-                      "lyric": {
-                        "M": {
-                          "serializedLyric": {
-                            "S": "\ue200"
-                          }
-                        }
-                      }
-                    }
-                  }
-                ]
-              }
-            }
-          },
-          {
-            "M": {
-              "type": {
-                "S": "ChordLine"
-              },
-              "elements": {
-                "L": [
-                  {
-                    "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
-                      "chord": {
-                        "S": "Em9"
-                      },
-                      "lyric": {
-                        "M": {
-                          "serializedLyric": {
-                            "S": "\ue400"
-                          }
-                        }
-                      }
-                    }
-                  },
-                  {
-                    "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
-                      "chord": {
-                        "S": "Bm7"
-                      },
-                      "lyric": {
-                        "M": {
-                          "serializedLyric": {
-                            "S": "\ue400"
-                          }
-                        }
-                      }
-                    }
-                  }
-                ]
-              }
-            }
-          },
-          {
-            "M": {
-              "type": {
-                "S": "ChordLine"
-              },
-              "elements": {
-                "L": [
-                  {
-                    "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
-                      "chord": {
-                        "S": "Am7"
-                      },
-                      "lyric": {
-                        "M": {
-                          "serializedLyric": {
-                            "S": "\ue400"
-                          }
-                        }
-                      }
-                    }
-                  },
-                  {
-                    "M": {
-                      "chord": {
-                        "S": "D7"
-                      },
-                      "type": {
-                        "S": "ChordBlock"
-                      },
-                      "lyric": {
-                        "M": {
-                          "serializedLyric": {
-                            "S": "\ue200"
-                          }
-                        }
-                      }
-                    }
-                  },
-                  {
-                    "M": {
-                      "chord": {
-                        "S": "Ebdim"
-                      },
-                      "type": {
-                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -27771,6 +28060,5163 @@
       "metadata": {
         "M": {
           "title": {
+            "S": "\u3082\u3046\u3048\u3048\u308f"
+          },
+          "composedBy": {
+            "S": "\u85e4\u4e95 \u98a8"
+          },
+          "performedBy": {
+            "S": "\u85e4\u4e95 \u98a8"
+          }
+        }
+      },
+      "owner": {
+        "S": "114135225559751053856"
+      },
+      "lastSavedAt": {
+        "S": "2022-06-14T04:51:43Z"
+      },
+      "id": {
+        "S": "fc71640e-739d-4c00-9490-dece41ca4c17"
+      },
+      "elements": {
+        "L": [
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "section": {
+                "M": {
+                  "name": {
+                    "S": "Intro"
+                  },
+                  "type": {
+                    "S": "time"
+                  },
+                  "time": {
+                    "N": "0"
+                  }
+                }
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Em7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200|"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Em7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Dm7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200|"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "C^"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200|"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Am7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "A/B"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue100"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "B7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue100|"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "section": {
+                "M": {
+                  "name": {
+                    "S": "Verse"
+                  },
+                  "type": {
+                    "S": "time"
+                  },
+                  "time": {
+                    "N": "12"
+                  }
+                }
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Em7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Saa hane no-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "bashite koko kara"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Em7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Torawarete "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Dm7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "bakka datta kara"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "C^"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Ikizumatte "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "yorokobi "
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Am7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "tebanasu "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "A/B"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "toki "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "B7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "wa i-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Em7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "ma"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Kokoro karu-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "kushite kore\u2005kara"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Em7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Jiyuu\u2005ni a-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Dm7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "ruite mitainara"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "C^"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Surechigatte\u2005"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "hito datte "
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Am7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "kakodatte "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "A^/B"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "kowakuna-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "E^"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "i"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "section": {
+                "M": {
+                  "name": {
+                    "S": "Prechorus"
+                  },
+                  "type": {
+                    "S": "time"
+                  },
+                  "time": {
+                    "N": "36"
+                  }
+                }
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Min-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "G#m7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "na saki "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "F#m7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "ga\u2005miena-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "B7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "i yomichi "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "E^"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "wa"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Tomo "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "G#m7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "ni mayo-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "F#m7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "i aruku "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "G#7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "yofuke do-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "C#m"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "ki"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Utsu-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "G#m7/B"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "mukanai-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "A^"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "de o-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "E/G#"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "bie-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Edim/G"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "nai-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "F#m7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "de"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Tozashita "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "A/B"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "tobira "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "B7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "tataite"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "section": {
+                "M": {
+                  "type": {
+                    "S": "time"
+                  },
+                  "name": {
+                    "S": "Chorus"
+                  },
+                  "time": {
+                    "N": "59"
+                  }
+                }
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Em7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Mo-Eh-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Wa"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "iware-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Am7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "ru maeni sakini i-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "D7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "washite"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Em7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Mo-Eh-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Wa "
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "yareru "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Am7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "dake yatte "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "D7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "ato wa makashite"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "G^"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Mo-Eh-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Dm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Wa "
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "ji-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "C^"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "yuuni naru-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "F7b9"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "wa"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Nakukurai "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Em7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "jattara "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Am7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "warattaru-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "A/B"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "wa"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "section": {
+                "M": {
+                  "type": {
+                    "S": "time"
+                  },
+                  "name": {
+                    "S": "Break"
+                  },
+                  "time": {
+                    "N": "82"
+                  }
+                }
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "A^"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Ahaha"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "G#m7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200|"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "F#m7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "A/B"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue100"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "B7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue100|"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Em7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200|"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Em7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Dm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200|"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "C^"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200|"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Am7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "A^/B"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue100"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "B7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue100|"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "section": {
+                "M": {
+                  "type": {
+                    "S": "time"
+                  },
+                  "name": {
+                    "S": "Verse"
+                  },
+                  "time": {
+                    "N": "100"
+                  }
+                }
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Em7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Kizuguchi wa "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "itsuka kasabuta"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Em7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Sugu hagare "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Dm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "ochite sayonara"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "C^"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Kokoro datte "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "sonna fuu ni "
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Am7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "ietara "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "A/B"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "ii "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "B7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "no ni na"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Em7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Maki koman-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "totte doronuma"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Em7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Imimo na-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Dm7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "ku tada "
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "kizutsu-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "C^"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "kerare soshite ki-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "zutsuke"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Ku-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Am7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "rikaesu "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "A/B"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "dake-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "B7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "e-e"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "section": {
+                "M": {
+                  "name": {
+                    "S": "Prechorus"
+                  },
+                  "type": {
+                    "S": "time"
+                  },
+                  "time": {
+                    "N": "123"
+                  }
+                }
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "E^"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue100Nuke-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "G#m7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "ta aho"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": " "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "F#m7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "na ge-mu "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "B7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "ichi nuketa"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "E^"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue100Yoru "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "G#m7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "ga same-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "F#m7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "ta"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": " kaze ni "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "G#7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "fukarete-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "C#m"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "ta"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Fura-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "G#m7/B"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "tsukanai-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "A^"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "de "
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "E/G#"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "fumi-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Edim/G"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "shime-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "F#m7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "te"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Uchinaru"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "A^/B"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue100kaze ni "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "B7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "fukarete"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "section": {
+                "M": {
+                  "name": {
+                    "S": "Chorus"
+                  },
+                  "type": {
+                    "S": "time"
+                  },
+                  "time": {
+                    "N": "147"
+                  }
+                }
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Em7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Mo-Eh-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Wa"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "iware-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Am7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "ru maeni "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "D7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "sakini iwashite"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Em7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Mo-Eh-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Wa "
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "tsuki-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Am7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "atte age-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "D7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "rende gomen ne"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "G^"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Mo-Eh-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Dm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Wa "
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "C^"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "jiyuu ni naru-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "F7b9"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "wa"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue100Nakukurai "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Em7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "jattara "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Am7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "warattaru-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "A/B"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "wa-"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "section": {
+                "M": {
+                  "name": {
+                    "S": "Bridge"
+                  },
+                  "type": {
+                    "S": "time"
+                  },
+                  "time": {
+                    "N": "170"
+                  }
+                }
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Yo ga "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "A^"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "fukete asa-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "E/G#"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "no hi-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Edim/G"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "ka-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "F#m7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "riga "
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "ka-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "A/B"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "o wo "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "B7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "dashite"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Em7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200|"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Em7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Dm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200|"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "C^"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200|"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Am7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "A/B"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue100"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "B7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue100|"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Em7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200|"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Em7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Dm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200|"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "C^"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200|"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Am7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "A/B"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue100"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "B7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue100|"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "section": {
+                "M": {
+                  "type": {
+                    "S": "time"
+                  },
+                  "name": {
+                    "S": "Major Chorus"
+                  },
+                  "time": {
+                    "N": "199"
+                  }
+                }
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "E^"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Mo-Eh-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "G#m7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Wa "
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "amai "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "F#m7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "yume bakka "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "A/B"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "misasentoite"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "E^"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Mo-Eh-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "G#m7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Wa "
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "iran-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "F#m7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "koto bakka "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "G#7b9"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "kikasentoite"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "C#m"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Mo-Eh-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "G#7/B#"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Wa "
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "teba-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "nashi-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Bb7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "tai "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "A^"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "mono "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "A/D"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "ima "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "F#m9"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "subete "
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "kono sora "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "A/B"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "ni sute-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "B7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "te"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "section": {
+                "M": {
+                  "type": {
+                    "S": "time"
+                  },
+                  "name": {
+                    "S": "Chorus"
+                  },
+                  "time": {
+                    "N": "222"
+                  }
+                }
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Em7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Mo-Eh-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Wa "
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "naniga "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Am7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "taisetsu "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "D7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "nan you erande"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Em7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Mo-Eh-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Wa "
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "sou o-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Am7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "mou nara "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "D7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "sassa tebanashite"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "G^"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Mo-Eh-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Dm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Wa "
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "C^"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "jiyuu ni "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "F7b9"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "naruwa"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue100Nakukurai "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Em7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "jattara "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Am7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "warattaru-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "A/B"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "wa"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "section": {
+                "M": {
+                  "name": {
+                    "S": "Outro"
+                  },
+                  "type": {
+                    "S": "time"
+                  },
+                  "time": {
+                    "N": "246"
+                  }
+                }
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "A^"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Ahaha"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "G#m7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200|"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "F#m7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "A/B"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue100"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "B7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue100|"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "E^"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "G#m7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200|"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "F#m7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "A/B"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue100"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "B7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue100|"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "E^"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "G#m7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200|"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "F#m7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "G#7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200|"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "C#m7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "G#7b9/B#"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200|"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Bm9"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue100"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Bb9"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue100"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "A@9"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue100"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "A/D"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue100|"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "F#m9"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue400|"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "A/B"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "B7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200|"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "E^"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "G#m7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200|"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "F#m7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "A/B"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue100"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "B7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue100|"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "E^"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "G#m7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200|"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "F#m7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "G#7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200|"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "C#m7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "G#7b9/B#"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200|"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Bm9"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue100"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Bb9"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue100"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "A@9"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue100"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "A/D"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue100|"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "F#m9"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue400|"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "A/B"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "B7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200|"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "metadata": {
+        "M": {
+          "title": {
             "S": "Lady (2020)"
           },
           "composedBy": {
@@ -34668,6 +40114,1826 @@
       "metadata": {
         "M": {
           "title": {
+            "S": "\u304d\u3089\u308a"
+          },
+          "performedBy": {
+            "S": "\u85e4\u4e95 \u98a8"
+          },
+          "composedBy": {
+            "S": "\u85e4\u4e95 \u98a8"
+          }
+        }
+      },
+      "owner": {
+        "S": "114135225559751053856"
+      },
+      "lastSavedAt": {
+        "S": "2022-05-14T04:25:41Z"
+      },
+      "id": {
+        "S": "ee0b5283-9815-4c06-ba7f-27d3d3154ef5"
+      },
+      "elements": {
+        "L": [
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Are kuruu kisetsu no naka wo"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Futari wa hitorikiri sarari"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Akeyuku yuuhi no naka wo"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Konya mo hirusagari sarari"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": ""
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Dore hodo kuchi hateyou to"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Saigo nya waraitai"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Nan no tame ni"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Tatakaou tomo douki wa ai ga ii"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Aah"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": ""
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Atarashii hibi wa"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Sagasazu tomo tsune ni koko ni (Koko ni)"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Iro iro mite kita keredo"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Kono hitomi wa towa ni kirari"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Are hodo ikite kita kedo"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Subete wa yume mitai"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Are mo kore mo"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Miryokuteki demo watashi wa kimi ga ii"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Aah"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": ""
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Doko ni ita no sagashiteta yo"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Tsuretette tsuretette"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Nani mo kamo suteteku yo"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Doko made mo doko made mo"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": ""
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Are kuruu kisetsu no naka mo"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Gunshuu no naka mo"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Kimi to naraba sarari sarari"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Atarashii hibi mo tsutanai kako mo"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Subete ga kirari"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": ""
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Nakushite shimatta"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Mono wo furikaette horori"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Toki ni wa tohou ni kurete"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Tada kaze ni fukaret\u0435 yurari"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": ""
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Ikiseki kitte kita no ikisaki wa kimeta no"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Mayowazu ni ikitai k\u0435do hoshou wa shinai yo"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Nanika wakatta you de nani mo wakatte nakute"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Dakedo sore ga wakatte hontou ni yokatta"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Atarashii hibi wa sagasazu tomo"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Tsune ni koko ni tsune ni koko ni koko ni"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Ah iro iro mite kita keredo kono hitomi wa"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Towa ni kirari towa ni kirari"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": ""
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Aah ikite kita kedo"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Subete wa yume mitai"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Are mo kore mo"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Miryokuteki demo"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Watashi wa kimi ga ii"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Aah, aah, aah, aah"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": ""
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Doko ni ita no sagashiteta yo"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Tsuretette tsuretette"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": ""
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Nani mo kamo suteteku yo"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Doko made mo doko made mo"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Are kuruu kisetsu no naka mo"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Gunshuu no naka mo kimi to naraba sarari"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Sarari"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Atarashii hibi mo"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Tsutanai kako mo"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Subete ga kirari, yeah"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "metadata": {
+        "M": {
+          "title": {
             "S": "Leeloo"
           },
           "composedBy": {
@@ -40022,6 +47288,2811 @@
                         "M": {
                           "serializedLyric": {
                             "S": ""
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "metadata": {
+        "M": {
+          "composedBy": {
+            "S": "Stock Aitken Waterman/Takeuchi/Gemosu"
+          },
+          "performedBy": {
+            "S": "Rick Astley x Mariya Takeuchi"
+          },
+          "title": {
+            "S": "Never Gonna Give You Up x Plastic Love"
+          },
+          "asHeardFrom": {
+            "S": "https://www.youtube.com/watch?v=dM9zwZCOmjM"
+          }
+        }
+      },
+      "owner": {
+        "S": "114135225559751053856"
+      },
+      "lastSavedAt": {
+        "S": "2022-06-16T18:06:11Z"
+      },
+      "id": {
+        "S": "6afc2560-1cab-48b7-b52a-a91da8b953c6"
+      },
+      "elements": {
+        "L": [
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "section": {
+                "M": {
+                  "name": {
+                    "S": "Intro"
+                  },
+                  "type": {
+                    "S": "time"
+                  },
+                  "time": {
+                    "N": "1"
+                  }
+                }
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "G^"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "F#m7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue100"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Em7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue100|"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Bm7b13/D"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "C13"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200|"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "G^"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "F#m7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200|"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "B7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue400|"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Em7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "A7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200|"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "F#m7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200|"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Em7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "A7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200|"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "F#m7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200|"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "section": {
+                "M": {
+                  "name": {
+                    "S": "Verse"
+                  },
+                  "type": {
+                    "S": "time"
+                  },
+                  "time": {
+                    "N": "30"
+                  }
+                }
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Em7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "We're no strangers to "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "A7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "love"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "F#m7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "You know the rules and "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "so do I"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Em7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "A full commitment's what I'm "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "C7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "thinking of"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "You wouldn't get this from "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "E7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "any other guy"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Em7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "I just wanna "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "A7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "tell you how I'm feeling"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue100Gotta make you understand"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "section": {
+                "M": {
+                  "type": {
+                    "S": "time"
+                  },
+                  "name": {
+                    "S": "Chorus"
+                  },
+                  "time": {
+                    "N": "58"
+                  }
+                }
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Never gonna "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Em9"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "give you up"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Never gonna "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "A7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "let you down"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Never gonna "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "F#m7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "run around and de-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "sert you"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Never gonna "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Em9"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "make you cry"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Never gonna "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "A7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "say goodbye"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Never gonna "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "F#m7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "tell a lie and "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "hurt you"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "section": {
+                "M": {
+                  "name": {
+                    "S": "Verse"
+                  },
+                  "type": {
+                    "S": "time"
+                  },
+                  "time": {
+                    "N": "76"
+                  }
+                }
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Em7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "We've known each other"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "C7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": " for so long"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Your heart's been aching but "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "E7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "you're too shy to say it"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Em7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Inside we both know what's been "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "A7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "going on"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "We know the game and we're"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": " gon-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "A7/C#"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "na "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "D7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "play it"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "G"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "And if you "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "A"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "ask me how I'm feeling"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "G"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue100Don't tell me you're too "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "A"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "blind to see"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "section": {
+                "M": {
+                  "name": {
+                    "S": "Chorus"
+                  },
+                  "type": {
+                    "S": "time"
+                  },
+                  "time": {
+                    "N": "104"
+                  }
+                }
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Never gonna "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "C#m11"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "give you "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "F#7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "up"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Never gonna "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "let you down"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Never gonna "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "G"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "run a-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "A"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "round and de-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "F#m7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "sert you"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Never gonna "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "G^"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "run a-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "F#m7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "round and de-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "B7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "sert you"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "section": {
+                "M": {
+                  "type": {
+                    "S": "time"
+                  },
+                  "name": {
+                    "S": "Guitar Solo"
+                  },
+                  "time": {
+                    "N": "121"
+                  }
+                }
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Em7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "C7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200|"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "E7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200|"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Em7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Never gonna give, never gonna give"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "A7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Never gonna give, never gonna give"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue100"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "A7/C#"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue100"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "D7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue100"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "section": {
+                "M": {
+                  "name": {
+                    "S": "Verse"
+                  },
+                  "type": {
+                    "S": "time"
+                  },
+                  "time": {
+                    "N": "140"
+                  }
+                }
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "G"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "We've known each other "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "A"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "for so long"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "G"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Your heart's been aching but "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "A"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "you're too shy to say it"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "C#m7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Inside we "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "F#7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "both know what's been"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": " going on"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "G"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "We know the "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "A"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "game and we're"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "F#m7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": " gonna "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "play it"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "G"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "I just wanna "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "A"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "tell you how I'm feeling"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "G"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue100Gotta make you"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "A"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": " understand"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Never gonna "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "G^"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "give you "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "F#m7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "up and de-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "B7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "sert you"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "section": {
+                "M": {
+                  "name": {
+                    "S": "Outro"
+                  },
+                  "type": {
+                    "S": "time"
+                  },
+                  "time": {
+                    "N": "174"
+                  }
+                }
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Never gonna "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Em9"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "give you up"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Never gonna "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "A7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "let you down"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Never gonna "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "F#m7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "run around and de-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "sert you"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Never gonna "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Em9"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "make you cry"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Never gonna "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "A7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "say goodbye"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Never gonna "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "F#m7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "tell a lie and "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "hurt you"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Never gonna "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Em9"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "give you up"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Never gonna "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "A7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "let you down"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Never gonna "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "F#m7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "run around and de-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "sert you"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Never gonna "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Em9"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "make you cry"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Never gonna "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "A7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "say goodbye"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Never gonna "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "F#m7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "tell a lie and "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "hurt you..."
                           }
                         }
                       }
@@ -45554,6 +55625,4185 @@
                         "M": {
                           "serializedLyric": {
                             "S": "\ue400"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "metadata": {
+        "M": {
+          "composedBy": {
+            "S": "\u8352\u8c37\u7fd4\u5927"
+          },
+          "performedBy": {
+            "S": "yonawo"
+          },
+          "title": {
+            "S": "\u77dc\u7faf\u7f85\u304c\u308b"
+          },
+          "asHeardFrom": {
+            "S": "https://www.youtube.com/watch?v=ZTTXhYPsUMA"
+          }
+        }
+      },
+      "owner": {
+        "S": "109453974626961032486"
+      },
+      "lastSavedAt": {
+        "S": "2022-04-13T23:40:22Z"
+      },
+      "id": {
+        "S": "e4a847fd-da00-4c32-ba4f-90e7a2847637"
+      },
+      "elements": {
+        "L": [
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "section": {
+                "M": {
+                  "type": {
+                    "S": "time"
+                  },
+                  "name": {
+                    "S": "Intro"
+                  },
+                  "time": {
+                    "N": "4"
+                  }
+                }
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "G^"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue100kimi wa "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "F#7b9"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Kongara-garu"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue100yatsu to "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Am7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Kongara-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "D7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "garu"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "G^"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue100taezu "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "F#7b9"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Kongara-garu"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue100"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Bbm7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue100yatsu to "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Am7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Kongara-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "D7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "garu"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "G^"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue400"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "F#7b9"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue400|"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200\ue100"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Bbm7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue100"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Am7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "D7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200|"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "G^"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue400"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "F#7b9"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue400|"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Bbm7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Am7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "D7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200|"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "section": {
+                "M": {
+                  "type": {
+                    "S": "time"
+                  },
+                  "name": {
+                    "S": "Verse"
+                  },
+                  "time": {
+                    "N": "33"
+                  }
+                }
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "G^"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue100ushi-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "F#7b9"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "ro metai "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "no "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Am7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "sa"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "D7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "koko-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "G^"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "ro mitai kedo"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "F#7b9"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": " aki-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "ra me-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Bbm7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "tai kedo"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Am7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue100"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "D7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "G^"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue100ari-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "F#7b9"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "fureteru "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "no sa"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Am7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue100"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "D7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "kimi "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "G^"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "no henji mo"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "F#7b9"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": " asu "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "no yu-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Bbm7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "kue "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Am7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "mo"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "D7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "section": {
+                "M": {
+                  "type": {
+                    "S": "time"
+                  },
+                  "name": {
+                    "S": "Prechorus"
+                  },
+                  "time": {
+                    "N": "59"
+                  }
+                }
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Gm9"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue100uchinomesa-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Am7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "re ima o mite "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "A/B"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "wa"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "D7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "kojirete-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Gm9"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "ta tamerai na-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Am7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "do tou ni sute-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "A/B"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "ta"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "D7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue100"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Am7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue100"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "D7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "section": {
+                "M": {
+                  "type": {
+                    "S": "time"
+                  },
+                  "name": {
+                    "S": "Chorus"
+                  },
+                  "time": {
+                    "N": "84"
+                  }
+                }
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "ishi wa "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "G^"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Kongara-gari "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "F#7b9"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "tokenai"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "akira-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "me nanka to "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Bbm7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "mo "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Am7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "irare-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "D7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "nai"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "ushiro-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "G^"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "yubi nara sashite "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "F#7b9"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "o kure yo"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "ho-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "ra i-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Bbm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "ma sa-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Am7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "se"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "D7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "yariba no "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "G^"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "nai omoi katate ni "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "F#7b9"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "burabura sage"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "iku ate mo "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Bbm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "nai "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Am7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "gogo ni deka-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "D7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "ke"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "G^"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "kimi wa kaeranu "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "F#7b9"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "mama"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "kimi wa "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Bbm7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "kaeranu "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Am7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "mama"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "D7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "section": {
+                "M": {
+                  "type": {
+                    "S": "time"
+                  },
+                  "name": {
+                    "S": "Verse"
+                  },
+                  "time": {
+                    "N": "112"
+                  }
+                }
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "G^"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue100yakusoku "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "F#7b9"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "nante tayori-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "nai ne"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "da kedo "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Am7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "matte i-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "D7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "tan da yo"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "G^"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue100kiseki "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "F#7b9"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "nante hana de wa-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "ratte"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "da "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Bbm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "kedo "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Am7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "itsu de mo i-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "D7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "notteru"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "G^"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue100nasake "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "F#7b9"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "nakutte yume o ka-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "jitte"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "nan to "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Am7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "naku de mo mawatte-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "D7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "ru"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "G^"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue100kono me ko-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "F#7b9"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "rashite kono me sora-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "shite"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Bbm7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "sonna "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Am7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "fuu ni kura-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "D7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "shiteru"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "section": {
+                "M": {
+                  "type": {
+                    "S": "time"
+                  },
+                  "name": {
+                    "S": "Instrumental"
+                  },
+                  "time": {
+                    "N": "138"
+                  }
+                }
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "G^"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue400"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "F#7b9"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue400|"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200\ue100"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Bbm7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue100"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Am7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "D7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200|"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "G^"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue400"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "F#7b9"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue400|"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Bbm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Am7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "D7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200|"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "G^"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue400"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "F#7b9"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue400|"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200\ue100"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Bbm7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue100"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Am7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "D7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200|"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "G^"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue400"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "F#7b9"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue400|"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Bbm7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Am7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "D7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200|"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "section": {
+                "M": {
+                  "name": {
+                    "S": "Chorus"
+                  },
+                  "type": {
+                    "S": "time"
+                  },
+                  "time": {
+                    "N": "162"
+                  }
+                }
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "ishi wa "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "G^"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Kongara-gari "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "F#7b9"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "tokenai"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "akira-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "me nanka to "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Bbm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "mo "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Am7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "irare-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "D7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "nai"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "ushiro-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "G^"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "yubi nara sashite "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "F#7b9"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "o kure yo"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "ho-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "ra i-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Bbm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "ma sa-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Am7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "se"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "D7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "yariba no "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "G^"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "nai omoi katate ni "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "F#7b9"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "burabura sage"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "iku ate mo "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Bbm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "nai "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Am7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "gogo ni deka-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "D7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "ke"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "G^"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "kimi wa kaeranu "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "F#7b9"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "mama"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "kimi wa "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Bbm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "kaeranu "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Am7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "mama"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "D7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200oh-oh"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "G^"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "oh-oh\ue100"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "F#7b9"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue400|"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "hey-yeah"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Bbm7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue100"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Am7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "D7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "da-la-da-da"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "G^"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue100Late in the "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "F#7b9"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "afternoon"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "No-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "where "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Bbm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "else to "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Am7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "go"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "D7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "But you "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "G^"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "just left\ue100"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "F#7b9"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "I'll "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "never "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Bbm7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "ever"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Am7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": " see "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "D7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "you a-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "G^"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "gain"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "F#7b9"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200\ue100"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Bbm7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue100"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Am7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "D7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue200|"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "section": {
+                "M": {
+                  "name": {
+                    "S": "Outro"
+                  },
+                  "type": {
+                    "S": "time"
+                  },
+                  "time": {
+                    "N": "214"
+                  }
+                }
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "G^"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue100kimi wa "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "F#7b9"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Kongara-garu"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue100yatsu to "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Am7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Kongara-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "D7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "garu"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "G^"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue100taezu "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "F#7b9"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Kongara-garu"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Bm7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue100"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Bbm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue100yatsu to "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Am7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Kongara-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "D7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "garu"
                           }
                         }
                       }
@@ -70326,6 +84576,1028 @@
     {
       "metadata": {
         "M": {
+          "title": {
+            "S": "Covered in Rain"
+          },
+          "composedBy": {
+            "S": "John Mayer"
+          },
+          "performedBy": {
+            "S": "John Mayer"
+          }
+        }
+      },
+      "owner": {
+        "S": "114135225559751053856"
+      },
+      "lastSavedAt": {
+        "S": "2022-06-20T03:27:09Z"
+      },
+      "id": {
+        "S": "be9d7fab-a057-4011-8bf1-91427b1e8f53"
+      },
+      "elements": {
+        "L": [
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "section": {
+                "M": {
+                  "type": {
+                    "S": "label"
+                  },
+                  "name": {
+                    "S": "Verse"
+                  }
+                }
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "And these days with the world getting colder"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "She spends more time sleeping over"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Than I planned"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": ""
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Tonight we're gonna order in"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Drinking wine and watching CNN"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "It's dark, I know"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "But then again"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "It's the brightest thing I've got"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "section": {
+                "M": {
+                  "name": {
+                    "S": "Chorus"
+                  },
+                  "type": {
+                    "S": "label"
+                  }
+                }
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "When I'm covered in rain, rain"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "When I'm covered in rain, rain, rain, rain"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": ""
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "section": {
+                "M": {
+                  "name": {
+                    "S": "Verse"
+                  },
+                  "type": {
+                    "S": "label"
+                  }
+                }
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "From fireworks to fireplaces"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Summer stole what fall replaces"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "And now, and now we're people watching"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "All the people, people watching us right back now"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Standing by the missing signs"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "At the CVS, by the checkout line"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "She puts her quiet hands in mine"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Cause she's the brightest thing I got"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "section": {
+                "M": {
+                  "type": {
+                    "S": "label"
+                  },
+                  "name": {
+                    "S": "Chorus"
+                  }
+                }
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Oh, I'm covered in rain"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Oh, I'm covered in rain"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Oh, I'm covered in rain"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "section": {
+                "M": {
+                  "type": {
+                    "S": "label"
+                  },
+                  "name": {
+                    "S": "Guitar Solo"
+                  }
+                }
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": ""
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "section": {
+                "M": {
+                  "type": {
+                    "S": "label"
+                  },
+                  "name": {
+                    "S": "Verse"
+                  }
+                }
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "And come December Lydia left"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "She mentioned something about it being for the best"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "And I can't say I disagree"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "And it's killing me"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "And now I'm standing facing west"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Tracing my fingers around a silhouette"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "I haven't gotten used to yet"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "But it's the brightest thing I got"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "section": {
+                "M": {
+                  "type": {
+                    "S": "label"
+                  },
+                  "name": {
+                    "S": "Outro"
+                  }
+                }
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "When I'm covered in rain"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "metadata": {
+        "M": {
           "performedBy": {
             "S": "tomita lab feat. Naz"
           },
@@ -78749,6 +94021,62 @@
                         "M": {
                           "serializedLyric": {
                             "S": "\ue200"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "metadata": {
+        "M": {
+          "title": {
+            "S": "\u30a8\u30a4\u30d7\u30ea\u30eb"
+          },
+          "performedBy": {
+            "S": "mol-74"
+          },
+          "composedBy": {
+            "S": ""
+          }
+        }
+      },
+      "owner": {
+        "S": "114135225559751053856"
+      },
+      "lastSavedAt": {
+        "S": "2022-07-11T17:55:12Z"
+      },
+      "id": {
+        "S": "bc0387ff-9643-43e1-a8b8-df972e0ad0b5"
+      },
+      "elements": {
+        "L": [
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": ""
                           }
                         }
                       }
@@ -93251,7 +108579,7 @@
         }
       },
       "owner": {
-        "S": "114135225559751053856"
+        "S": "demo"
       },
       "lastSavedAt": {
         "S": "2021-09-22T09:05:39Z"
@@ -93283,11 +108611,11 @@
                 "L": [
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "G^"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -93317,11 +108645,11 @@
                   },
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "Em7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -93379,11 +108707,11 @@
                 "L": [
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "G^"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -93396,11 +108724,11 @@
                   },
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "F#m7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -93413,11 +108741,11 @@
                   },
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "B7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -93475,11 +108803,11 @@
                   },
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "F#m7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -93492,11 +108820,11 @@
                   },
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "Bm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -93537,11 +108865,11 @@
                   },
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "A7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -93674,11 +109002,11 @@
                   },
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "Bm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -93702,11 +109030,11 @@
                 "L": [
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "Em7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -93719,11 +109047,11 @@
                   },
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "C7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -93792,11 +109120,11 @@
                 "L": [
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "Em7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -93809,11 +109137,11 @@
                   },
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "A7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -93837,11 +109165,11 @@
                 "L": [
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "Bm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -93863,11 +109191,11 @@
               },
               "section": {
                 "M": {
-                  "type": {
-                    "S": "time"
-                  },
                   "name": {
                     "S": "Chorus"
+                  },
+                  "type": {
+                    "S": "time"
                   },
                   "time": {
                     "N": "58"
@@ -93878,11 +109206,11 @@
                 "L": [
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -93923,11 +109251,11 @@
                 "L": [
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -93940,11 +109268,11 @@
                   },
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "A7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -93968,11 +109296,11 @@
                 "L": [
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -94002,11 +109330,11 @@
                   },
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "Bm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -94075,11 +109403,11 @@
                 "L": [
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -94120,11 +109448,11 @@
                 "L": [
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -94137,11 +109465,11 @@
                   },
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "F#m7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -94212,11 +109540,11 @@
                   },
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "C7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -94257,11 +109585,11 @@
                   },
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "E7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -94302,11 +109630,11 @@
                   },
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "A7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -94330,11 +109658,11 @@
                 "L": [
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "Bm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -94347,11 +109675,11 @@
                   },
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "Bm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -94381,11 +109709,11 @@
                   },
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "D7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -94409,11 +109737,11 @@
                 "L": [
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "G"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -94454,11 +109782,11 @@
                 "L": [
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "G"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -94497,11 +109825,11 @@
               },
               "section": {
                 "M": {
-                  "type": {
-                    "S": "time"
-                  },
                   "name": {
                     "S": "Chorus"
+                  },
+                  "type": {
+                    "S": "time"
                   },
                   "time": {
                     "N": "104"
@@ -94512,11 +109840,11 @@
                 "L": [
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -94546,11 +109874,11 @@
                   },
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "F#7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -94591,11 +109919,11 @@
                   },
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "Bm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -94619,11 +109947,11 @@
                 "L": [
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -94653,11 +109981,11 @@
                   },
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "A"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -94670,11 +109998,11 @@
                   },
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "F#m7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -94732,11 +110060,11 @@
                   },
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "G^"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -94749,11 +110077,11 @@
                   },
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "F#m7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -94766,11 +110094,11 @@
                   },
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "B7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -94792,11 +110120,11 @@
               },
               "section": {
                 "M": {
-                  "type": {
-                    "S": "time"
-                  },
                   "name": {
                     "S": "Guitar Solo"
+                  },
+                  "type": {
+                    "S": "time"
                   },
                   "time": {
                     "N": "121"
@@ -94807,11 +110135,11 @@
                 "L": [
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "Em7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -94841,11 +110169,11 @@
                   },
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "Bm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -94886,11 +110214,11 @@
                 "L": [
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "Em7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -94903,11 +110231,11 @@
                   },
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "A7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -94931,11 +110259,11 @@
                 "L": [
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "Bm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -95068,11 +110396,11 @@
                 "L": [
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "G"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -95085,11 +110413,11 @@
                   },
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "A"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -95113,11 +110441,11 @@
                 "L": [
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "C#m7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -95226,11 +110554,11 @@
                   },
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "Bm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -95271,11 +110599,11 @@
                   },
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "A"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -95344,11 +110672,11 @@
                 "L": [
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -95395,11 +110723,11 @@
                   },
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "B7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -95453,11 +110781,11 @@
                   },
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "Em9"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -95481,11 +110809,11 @@
                 "L": [
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -95526,11 +110854,11 @@
                 "L": [
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -95560,11 +110888,11 @@
                   },
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "Bm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -95633,11 +110961,11 @@
                 "L": [
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -95650,11 +110978,11 @@
                   },
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "A7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -95695,11 +111023,11 @@
                   },
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "F#m7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -95757,11 +111085,11 @@
                   },
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "Em9"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -95892,11 +111220,11 @@
                 "L": [
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -95954,11 +111282,11 @@
                   },
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "A7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -95999,11 +111327,11 @@
                   },
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "F#m7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -96016,11 +111344,11 @@
                   },
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "Bm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -104308,11 +119636,11 @@
           "title": {
             "S": "Bossa"
           },
-          "performedBy": {
-            "S": "Sala feat. FLEUR, \u718a\u4e95\u543e\u90ce"
-          },
           "composedBy": {
             "S": "Ryoma Takamura, FLEUR"
+          },
+          "performedBy": {
+            "S": "Sala feat. FLEUR, \u718a\u4e95\u543e\u90ce"
           }
         }
       },
@@ -104320,7 +119648,7 @@
         "S": "114135225559751053856"
       },
       "lastSavedAt": {
-        "S": "2022-03-10T03:49:35Z"
+        "S": "2022-04-16T05:23:50Z"
       },
       "id": {
         "S": "8b43589b-0eb3-400e-bc6c-a59c038c62d2"
@@ -104349,11 +119677,11 @@
                 "L": [
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "Bbm9"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -104366,11 +119694,11 @@
                   },
                   {
                     "M": {
-                      "chord": {
-                        "S": "Db^/Eb"
-                      },
                       "type": {
                         "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Db^/Eb"
                       },
                       "lyric": {
                         "M": {
@@ -104501,11 +119829,11 @@
                   },
                   {
                     "M": {
-                      "chord": {
-                        "S": "F7b9"
-                      },
                       "type": {
                         "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "F7b9"
                       },
                       "lyric": {
                         "M": {
@@ -104527,11 +119855,11 @@
               },
               "section": {
                 "M": {
-                  "name": {
-                    "S": "Chorus"
-                  },
                   "type": {
                     "S": "time"
+                  },
+                  "name": {
+                    "S": "Chorus"
                   },
                   "time": {
                     "N": "12"
@@ -104559,11 +119887,11 @@
                   },
                   {
                     "M": {
-                      "chord": {
-                        "S": "Bbm9"
-                      },
                       "type": {
                         "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Bbm9"
                       },
                       "lyric": {
                         "M": {
@@ -104576,11 +119904,11 @@
                   },
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "Db^/Eb"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -104604,11 +119932,11 @@
                 "L": [
                   {
                     "M": {
-                      "chord": {
-                        "S": ""
-                      },
                       "type": {
                         "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
                       },
                       "lyric": {
                         "M": {
@@ -104621,11 +119949,11 @@
                   },
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "Cm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -104666,11 +119994,11 @@
                 "L": [
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -104683,11 +120011,11 @@
                   },
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "Bbm9"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -104700,11 +120028,11 @@
                   },
                   {
                     "M": {
-                      "chord": {
-                        "S": "Db^/Eb"
-                      },
                       "type": {
                         "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Db^/Eb"
                       },
                       "lyric": {
                         "M": {
@@ -104728,11 +120056,11 @@
                 "L": [
                   {
                     "M": {
-                      "chord": {
-                        "S": ""
-                      },
                       "type": {
                         "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
                       },
                       "lyric": {
                         "M": {
@@ -104807,11 +120135,11 @@
                   },
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "Db^/Eb"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -104869,11 +120197,11 @@
                   },
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "F7b9"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -104914,11 +120242,11 @@
                   },
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "Bbm9"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -104931,11 +120259,11 @@
                   },
                   {
                     "M": {
-                      "chord": {
-                        "S": "Db^/Eb"
-                      },
                       "type": {
                         "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Db^/Eb"
                       },
                       "lyric": {
                         "M": {
@@ -104976,11 +120304,11 @@
                   },
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "Cm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -105004,11 +120332,11 @@
                 "L": [
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -105124,11 +120452,11 @@
                   },
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "F7b9"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -105169,11 +120497,11 @@
                   },
                   {
                     "M": {
-                      "chord": {
-                        "S": "Db^/Eb"
-                      },
                       "type": {
                         "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Db^/Eb"
                       },
                       "lyric": {
                         "M": {
@@ -105197,11 +120525,11 @@
                 "L": [
                   {
                     "M": {
-                      "chord": {
-                        "S": "Cm7"
-                      },
                       "type": {
                         "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Cm7"
                       },
                       "lyric": {
                         "M": {
@@ -105321,11 +120649,11 @@
                   },
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "Cm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -105338,11 +120666,11 @@
                   },
                   {
                     "M": {
-                      "chord": {
-                        "S": "F7b9"
-                      },
                       "type": {
                         "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "F7b9"
                       },
                       "lyric": {
                         "M": {
@@ -105383,11 +120711,11 @@
                   },
                   {
                     "M": {
-                      "chord": {
-                        "S": "Db^/Eb"
-                      },
                       "type": {
                         "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Db^/Eb"
                       },
                       "lyric": {
                         "M": {
@@ -105428,11 +120756,11 @@
                   },
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "Cm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -105445,11 +120773,11 @@
                   },
                   {
                     "M": {
-                      "chord": {
-                        "S": "F7b9"
-                      },
                       "type": {
                         "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "F7b9"
                       },
                       "lyric": {
                         "M": {
@@ -105473,11 +120801,11 @@
                 "L": [
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "Bbm9"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -105518,11 +120846,11 @@
                 "L": [
                   {
                     "M": {
-                      "chord": {
-                        "S": "Cm7"
-                      },
                       "type": {
                         "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Cm7"
                       },
                       "lyric": {
                         "M": {
@@ -105535,11 +120863,11 @@
                   },
                   {
                     "M": {
-                      "chord": {
-                        "S": "F7b9"
-                      },
                       "type": {
                         "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "F7b9"
                       },
                       "lyric": {
                         "M": {
@@ -105625,11 +120953,11 @@
                   },
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "Cm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -105668,11 +120996,11 @@
               },
               "section": {
                 "M": {
-                  "name": {
-                    "S": "Chorus"
-                  },
                   "type": {
                     "S": "time"
+                  },
+                  "name": {
+                    "S": "Chorus"
                   },
                   "time": {
                     "N": "76"
@@ -105683,11 +121011,11 @@
                 "L": [
                   {
                     "M": {
-                      "chord": {
-                        "S": ""
-                      },
                       "type": {
                         "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
                       },
                       "lyric": {
                         "M": {
@@ -105700,11 +121028,11 @@
                   },
                   {
                     "M": {
-                      "chord": {
-                        "S": "Bbm9"
-                      },
                       "type": {
                         "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Bbm9"
                       },
                       "lyric": {
                         "M": {
@@ -105717,11 +121045,11 @@
                   },
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "Db^/Eb"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -105762,11 +121090,11 @@
                   },
                   {
                     "M": {
-                      "chord": {
-                        "S": "Cm7"
-                      },
                       "type": {
                         "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Cm7"
                       },
                       "lyric": {
                         "M": {
@@ -105779,11 +121107,11 @@
                   },
                   {
                     "M": {
-                      "chord": {
-                        "S": "F7b9"
-                      },
                       "type": {
                         "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "F7b9"
                       },
                       "lyric": {
                         "M": {
@@ -105841,11 +121169,11 @@
                   },
                   {
                     "M": {
-                      "chord": {
-                        "S": "Db^/Eb"
-                      },
                       "type": {
                         "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Db^/Eb"
                       },
                       "lyric": {
                         "M": {
@@ -105869,11 +121197,11 @@
                 "L": [
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": ""
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -105929,11 +121257,11 @@
               },
               "section": {
                 "M": {
-                  "name": {
-                    "S": "Break"
-                  },
                   "type": {
                     "S": "label"
+                  },
+                  "name": {
+                    "S": "Break"
                   }
                 }
               },
@@ -105941,11 +121269,101 @@
                 "L": [
                   {
                     "M": {
+                      "chord": {
+                        "S": "Bbm9"
+                      },
                       "type": {
                         "S": "ChordBlock"
                       },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue400"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Db^/Eb"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue400"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Cm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue400"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "F7b9"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue400"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
                       "chord": {
                         "S": "Bbm9"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -106048,11 +121466,11 @@
                   },
                   {
                     "M": {
-                      "chord": {
-                        "S": "Db^/Eb"
-                      },
                       "type": {
                         "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Db^/Eb"
                       },
                       "lyric": {
                         "M": {
@@ -106138,96 +121556,6 @@
                   },
                   {
                     "M": {
-                      "chord": {
-                        "S": "Db^/Eb"
-                      },
-                      "type": {
-                        "S": "ChordBlock"
-                      },
-                      "lyric": {
-                        "M": {
-                          "serializedLyric": {
-                            "S": "\ue400"
-                          }
-                        }
-                      }
-                    }
-                  }
-                ]
-              }
-            }
-          },
-          {
-            "M": {
-              "type": {
-                "S": "ChordLine"
-              },
-              "elements": {
-                "L": [
-                  {
-                    "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
-                      "chord": {
-                        "S": "Cm7"
-                      },
-                      "lyric": {
-                        "M": {
-                          "serializedLyric": {
-                            "S": "\ue400"
-                          }
-                        }
-                      }
-                    }
-                  },
-                  {
-                    "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
-                      "chord": {
-                        "S": "F7b9"
-                      },
-                      "lyric": {
-                        "M": {
-                          "serializedLyric": {
-                            "S": "\ue400"
-                          }
-                        }
-                      }
-                    }
-                  }
-                ]
-              }
-            }
-          },
-          {
-            "M": {
-              "type": {
-                "S": "ChordLine"
-              },
-              "elements": {
-                "L": [
-                  {
-                    "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
-                      "chord": {
-                        "S": "Bbm9"
-                      },
-                      "lyric": {
-                        "M": {
-                          "serializedLyric": {
-                            "S": "\ue400"
-                          }
-                        }
-                      }
-                    }
-                  },
-                  {
-                    "M": {
                       "type": {
                         "S": "ChordBlock"
                       },
@@ -106273,11 +121601,11 @@
                   },
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "F7b9"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -106299,11 +121627,11 @@
               },
               "section": {
                 "M": {
-                  "name": {
-                    "S": "Chorus"
-                  },
                   "type": {
                     "S": "time"
+                  },
+                  "name": {
+                    "S": "Chorus"
                   },
                   "time": {
                     "N": "115"
@@ -106314,8 +121642,25 @@
                 "L": [
                   {
                     "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
                       "chord": {
                         "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "you're still "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Bbm9"
                       },
                       "type": {
                         "S": "ChordBlock"
@@ -106323,63 +121668,24 @@
                       "lyric": {
                         "M": {
                           "serializedLyric": {
-                            "S": "you're still sleepy but sorry"
+                            "S": "sleepy but "
                           }
                         }
                       }
                     }
-                  }
-                ]
-              }
-            }
-          },
-          {
-            "M": {
-              "type": {
-                "S": "ChordLine"
-              },
-              "elements": {
-                "L": [
+                  },
                   {
                     "M": {
                       "type": {
                         "S": "ChordBlock"
                       },
                       "chord": {
-                        "S": ""
+                        "S": "Db^/Eb"
                       },
                       "lyric": {
                         "M": {
                           "serializedLyric": {
-                            "S": "nemui me kosuri mukawanakya Job ni"
-                          }
-                        }
-                      }
-                    }
-                  }
-                ]
-              }
-            }
-          },
-          {
-            "M": {
-              "type": {
-                "S": "ChordLine"
-              },
-              "elements": {
-                "L": [
-                  {
-                    "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
-                      "chord": {
-                        "S": ""
-                      },
-                      "lyric": {
-                        "M": {
-                          "serializedLyric": {
-                            "S": "kinou no kaori ga nokoru floor ni"
+                            "S": "sorry"
                           }
                         }
                       }
@@ -106407,63 +121713,41 @@
                       "lyric": {
                         "M": {
                           "serializedLyric": {
-                            "S": "Coffee beans o kirashite"
+                            "S": "nemui me ko-"
                           }
                         }
                       }
                     }
-                  }
-                ]
-              }
-            }
-          },
-          {
-            "M": {
-              "type": {
-                "S": "ChordLine"
-              },
-              "elements": {
-                "L": [
+                  },
                   {
                     "M": {
                       "type": {
                         "S": "ChordBlock"
                       },
                       "chord": {
-                        "S": ""
+                        "S": "Cm7"
                       },
                       "lyric": {
                         "M": {
                           "serializedLyric": {
-                            "S": "kamomi-ru ni miruku"
+                            "S": "suri mukawanakya "
                           }
                         }
                       }
                     }
-                  }
-                ]
-              }
-            }
-          },
-          {
-            "M": {
-              "type": {
-                "S": "ChordLine"
-              },
-              "elements": {
-                "L": [
+                  },
                   {
                     "M": {
                       "type": {
                         "S": "ChordBlock"
                       },
                       "chord": {
-                        "S": ""
+                        "S": "F7b9"
                       },
                       "lyric": {
                         "M": {
                           "serializedLyric": {
-                            "S": "toui hodo itoshii"
+                            "S": "Job ni"
                           }
                         }
                       }
@@ -106491,7 +121775,41 @@
                       "lyric": {
                         "M": {
                           "serializedLyric": {
-                            "S": "yasashii roman wa kare mo Genuine"
+                            "S": "kinou no kao-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Bbm9"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "ri ga nokoru "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Db^/Eb"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "floor ni"
                           }
                         }
                       }
@@ -106519,7 +121837,114 @@
                       "lyric": {
                         "M": {
                           "serializedLyric": {
-                            "S": "awai kaori de iyasu Heartache"
+                            "S": "Coffee "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Cm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "beans o kirashite"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "ka-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "F7b9"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "momi-ru ni miruku"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Bbm9"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "toui hodo i-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Db^/Eb"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "toshii"
                           }
                         }
                       }
@@ -106547,7 +121972,41 @@
                       "lyric": {
                         "M": {
                           "serializedLyric": {
-                            "S": "naminami no kappu ni utsuru"
+                            "S": "yasashi-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Cm7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "i roman wa kare mo "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "F7b9"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Genuine"
                           }
                         }
                       }
@@ -106575,7 +122034,131 @@
                       "lyric": {
                         "M": {
                           "serializedLyric": {
-                            "S": "futari wa Blendy"
+                            "S": "awai kao-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Bbm9"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "ri de iyasu "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Db^/Eb"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "Heartache"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "naminami no "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Cm7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "kappu ni utsuru"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "fu-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "F7b9"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "tari wa Blendy"
                           }
                         }
                       }
@@ -106592,11 +122175,11 @@
               },
               "section": {
                 "M": {
-                  "type": {
-                    "S": "time"
-                  },
                   "name": {
                     "S": "Verse"
+                  },
+                  "type": {
+                    "S": "time"
                   },
                   "time": {
                     "N": "141"
@@ -106607,8 +122190,25 @@
                 "L": [
                   {
                     "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
                       "chord": {
-                        "S": ""
+                        "S": "Bbm9"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue100asa okitetsu-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Db^/Eb"
                       },
                       "type": {
                         "S": "ChordBlock"
@@ -106616,7 +122216,97 @@
                       "lyric": {
                         "M": {
                           "serializedLyric": {
-                            "S": "asa okitetsukeru shigaretto"
+                            "S": "keru shigaretto"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Cm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue100sou ieba na-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "F7b9"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "ni mo itte nee"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Bbm9"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "\ue100kaoru nioi ki-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Db^/Eb"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "mi no nioi"
                           }
                         }
                       }
@@ -106644,7 +122334,221 @@
                       "lyric": {
                         "M": {
                           "serializedLyric": {
-                            "S": "sou ieba nani mo itte nee"
+                            "S": "mazari-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Cm7"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "atte henka ni mo "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "F7b9"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "ki zukenai"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Bbm9"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "nee do-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Db^/Eb"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "u?"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Cm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "nee do-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "F7b9"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "u?"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Bbm9"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "tama ni wa kotoba ni shi-"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Db^/Eb"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "nai to na"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "M": {
+              "type": {
+                "S": "ChordLine"
+              },
+              "elements": {
+                "L": [
+                  {
+                    "M": {
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": ""
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "beta-na "
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "M": {
+                      "chord": {
+                        "S": "Cm7"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
+                      },
+                      "lyric": {
+                        "M": {
+                          "serializedLyric": {
+                            "S": "choisu"
                           }
                         }
                       }
@@ -106672,27 +122576,16 @@
                       "lyric": {
                         "M": {
                           "serializedLyric": {
-                            "S": "kaoru nioi kimi no nioi"
+                            "S": "bita-na choisu"
                           }
                         }
                       }
                     }
-                  }
-                ]
-              }
-            }
-          },
-          {
-            "M": {
-              "type": {
-                "S": "ChordLine"
-              },
-              "elements": {
-                "L": [
+                  },
                   {
                     "M": {
                       "chord": {
-                        "S": ""
+                        "S": "F7b9"
                       },
                       "type": {
                         "S": "ChordBlock"
@@ -106700,147 +122593,7 @@
                       "lyric": {
                         "M": {
                           "serializedLyric": {
-                            "S": "mazariatte henka ni mo ki zukenai"
-                          }
-                        }
-                      }
-                    }
-                  }
-                ]
-              }
-            }
-          },
-          {
-            "M": {
-              "type": {
-                "S": "ChordLine"
-              },
-              "elements": {
-                "L": [
-                  {
-                    "M": {
-                      "chord": {
-                        "S": ""
-                      },
-                      "type": {
-                        "S": "ChordBlock"
-                      },
-                      "lyric": {
-                        "M": {
-                          "serializedLyric": {
-                            "S": "nee dou ?"
-                          }
-                        }
-                      }
-                    }
-                  }
-                ]
-              }
-            }
-          },
-          {
-            "M": {
-              "type": {
-                "S": "ChordLine"
-              },
-              "elements": {
-                "L": [
-                  {
-                    "M": {
-                      "chord": {
-                        "S": ""
-                      },
-                      "type": {
-                        "S": "ChordBlock"
-                      },
-                      "lyric": {
-                        "M": {
-                          "serializedLyric": {
-                            "S": "nee dou ?"
-                          }
-                        }
-                      }
-                    }
-                  }
-                ]
-              }
-            }
-          },
-          {
-            "M": {
-              "type": {
-                "S": "ChordLine"
-              },
-              "elements": {
-                "L": [
-                  {
-                    "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
-                      "chord": {
-                        "S": ""
-                      },
-                      "lyric": {
-                        "M": {
-                          "serializedLyric": {
-                            "S": "tama ni wa kotoba ni shinai to na"
-                          }
-                        }
-                      }
-                    }
-                  }
-                ]
-              }
-            }
-          },
-          {
-            "M": {
-              "type": {
-                "S": "ChordLine"
-              },
-              "elements": {
-                "L": [
-                  {
-                    "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
-                      "chord": {
-                        "S": ""
-                      },
-                      "lyric": {
-                        "M": {
-                          "serializedLyric": {
-                            "S": "beta-na choisu"
-                          }
-                        }
-                      }
-                    }
-                  }
-                ]
-              }
-            }
-          },
-          {
-            "M": {
-              "type": {
-                "S": "ChordLine"
-              },
-              "elements": {
-                "L": [
-                  {
-                    "M": {
-                      "chord": {
-                        "S": ""
-                      },
-                      "type": {
-                        "S": "ChordBlock"
-                      },
-                      "lyric": {
-                        "M": {
-                          "serializedLyric": {
-                            "S": "bita-na choisu ..."
+                            "S": "\ue200"
                           }
                         }
                       }
@@ -106885,11 +122638,11 @@
               },
               "section": {
                 "M": {
-                  "type": {
-                    "S": "label"
-                  },
                   "name": {
                     "S": "Outro"
+                  },
+                  "type": {
+                    "S": "label"
                   }
                 }
               },
@@ -106897,11 +122650,11 @@
                 "L": [
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "Bbm9"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -106959,11 +122712,11 @@
                   },
                   {
                     "M": {
-                      "type": {
-                        "S": "ChordBlock"
-                      },
                       "chord": {
                         "S": "F7b9"
+                      },
+                      "type": {
+                        "S": "ChordBlock"
                       },
                       "lyric": {
                         "M": {
@@ -107004,11 +122757,11 @@
                   },
                   {
                     "M": {
-                      "chord": {
-                        "S": "Db^/Eb"
-                      },
                       "type": {
                         "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "Db^/Eb"
                       },
                       "lyric": {
                         "M": {
@@ -107049,11 +122802,11 @@
                   },
                   {
                     "M": {
-                      "chord": {
-                        "S": "F7b9"
-                      },
                       "type": {
                         "S": "ChordBlock"
+                      },
+                      "chord": {
+                        "S": "F7b9"
                       },
                       "lyric": {
                         "M": {
@@ -121920,5 +137673,5 @@
       }
     }
   ],
-  "ScannedCount": 52
+  "ScannedCount": 58
 }

--- a/db_dump/Songs/schema.json
+++ b/db_dump/Songs/schema.json
@@ -15,9 +15,9 @@
       {
         "IndexArn": "arn:aws:dynamodb:us-east-2:579696076733:table/Songs/index/owner-index",
         "IndexName": "owner-index",
-        "IndexSizeBytes": 427745,
+        "IndexSizeBytes": 482614,
         "IndexStatus": "ACTIVE",
-        "ItemCount": 52,
+        "ItemCount": 58,
         "KeySchema": [
           {
             "AttributeName": "owner",
@@ -34,7 +34,7 @@
         }
       }
     ],
-    "ItemCount": 52,
+    "ItemCount": 58,
     "KeySchema": [
       {
         "AttributeName": "id",
@@ -49,7 +49,7 @@
     "TableArn": "arn:aws:dynamodb:us-east-2:579696076733:table/Songs",
     "TableId": "8240ca7e-0116-4438-92dc-cc6f2cbd1646",
     "TableName": "Songs",
-    "TableSizeBytes": 427745,
+    "TableSizeBytes": 482614,
     "TableStatus": "ACTIVE"
   }
 }

--- a/db_dump/TrackLists/data/0001.json
+++ b/db_dump/TrackLists/data/0001.json
@@ -1,5 +1,5 @@
 {
-  "Count": 42,
+  "Count": 46,
   "Items": [
     {
       "tracks": {
@@ -595,6 +595,50 @@
           {
             "M": {
               "id": {
+                "S": "1c426210-1109-4de8-85b8-f8bd55147fac"
+              },
+              "label": {
+                "S": "5 stems"
+              },
+              "original_url": {
+                "S": "https://www.youtube.com/watch?v=y4FYCJRjHBg"
+              },
+              "stem_urls": {
+                "M": {
+                  "vocals": {
+                    "S": "https://storage.googleapis.com/chord-paper-tracks/fc71640e-739d-4c00-9490-dece41ca4c17/1c426210-1109-4de8-85b8-f8bd55147fac/5stems/vocals.mp3"
+                  },
+                  "bass": {
+                    "S": "https://storage.googleapis.com/chord-paper-tracks/fc71640e-739d-4c00-9490-dece41ca4c17/1c426210-1109-4de8-85b8-f8bd55147fac/5stems/bass.mp3"
+                  },
+                  "other": {
+                    "S": "https://storage.googleapis.com/chord-paper-tracks/fc71640e-739d-4c00-9490-dece41ca4c17/1c426210-1109-4de8-85b8-f8bd55147fac/5stems/other.mp3"
+                  },
+                  "piano": {
+                    "S": "https://storage.googleapis.com/chord-paper-tracks/fc71640e-739d-4c00-9490-dece41ca4c17/1c426210-1109-4de8-85b8-f8bd55147fac/5stems/piano.mp3"
+                  },
+                  "drums": {
+                    "S": "https://storage.googleapis.com/chord-paper-tracks/fc71640e-739d-4c00-9490-dece41ca4c17/1c426210-1109-4de8-85b8-f8bd55147fac/5stems/drums.mp3"
+                  }
+                }
+              },
+              "track_type": {
+                "S": "5stems"
+              }
+            }
+          }
+        ]
+      },
+      "song_id": {
+        "S": "fc71640e-739d-4c00-9490-dece41ca4c17"
+      }
+    },
+    {
+      "tracks": {
+        "L": [
+          {
+            "M": {
+              "id": {
                 "S": "de54e6ff-02d4-449c-ab3e-5f11bf5e474f"
               },
               "label": {
@@ -688,6 +732,47 @@
       },
       "song_id": {
         "S": "0df03293-25ff-4deb-9b7e-23c277651263"
+      }
+    },
+    {
+      "tracks": {
+        "L": [
+          {
+            "M": {
+              "id": {
+                "S": "fabaa146-3858-4af6-b85b-6ab4f863eb97"
+              },
+              "label": {
+                "S": "4 stems"
+              },
+              "original_url": {
+                "S": "https://www.youtube.com/watch?v=TcLLpZBWsck"
+              },
+              "stem_urls": {
+                "M": {
+                  "vocals": {
+                    "S": "https://storage.googleapis.com/chord-paper-tracks/ee0b5283-9815-4c06-ba7f-27d3d3154ef5/fabaa146-3858-4af6-b85b-6ab4f863eb97/4stems/vocals.mp3"
+                  },
+                  "bass": {
+                    "S": "https://storage.googleapis.com/chord-paper-tracks/ee0b5283-9815-4c06-ba7f-27d3d3154ef5/fabaa146-3858-4af6-b85b-6ab4f863eb97/4stems/bass.mp3"
+                  },
+                  "other": {
+                    "S": "https://storage.googleapis.com/chord-paper-tracks/ee0b5283-9815-4c06-ba7f-27d3d3154ef5/fabaa146-3858-4af6-b85b-6ab4f863eb97/4stems/other.mp3"
+                  },
+                  "drums": {
+                    "S": "https://storage.googleapis.com/chord-paper-tracks/ee0b5283-9815-4c06-ba7f-27d3d3154ef5/fabaa146-3858-4af6-b85b-6ab4f863eb97/4stems/drums.mp3"
+                  }
+                }
+              },
+              "track_type": {
+                "S": "4stems"
+              }
+            }
+          }
+        ]
+      },
+      "song_id": {
+        "S": "ee0b5283-9815-4c06-ba7f-27d3d3154ef5"
       }
     },
     {
@@ -849,6 +934,47 @@
       },
       "song_id": {
         "S": "14338ee4-5a96-4653-a45c-9211d4cad5e5"
+      }
+    },
+    {
+      "tracks": {
+        "L": [
+          {
+            "M": {
+              "id": {
+                "S": "ab847f93-00a4-4d1d-8e0f-a950273f4b8c"
+              },
+              "label": {
+                "S": "awef"
+              },
+              "original_url": {
+                "S": "https://www.youtube.com/watch?v=6-MyfXR_RaE"
+              },
+              "stem_urls": {
+                "M": {
+                  "vocals": {
+                    "S": "https://storage.googleapis.com/chord-paper-tracks/e4a847fd-da00-4c32-ba4f-90e7a2847637/ab847f93-00a4-4d1d-8e0f-a950273f4b8c/4stems/vocals.mp3"
+                  },
+                  "bass": {
+                    "S": "https://storage.googleapis.com/chord-paper-tracks/e4a847fd-da00-4c32-ba4f-90e7a2847637/ab847f93-00a4-4d1d-8e0f-a950273f4b8c/4stems/bass.mp3"
+                  },
+                  "other": {
+                    "S": "https://storage.googleapis.com/chord-paper-tracks/e4a847fd-da00-4c32-ba4f-90e7a2847637/ab847f93-00a4-4d1d-8e0f-a950273f4b8c/4stems/other.mp3"
+                  },
+                  "drums": {
+                    "S": "https://storage.googleapis.com/chord-paper-tracks/e4a847fd-da00-4c32-ba4f-90e7a2847637/ab847f93-00a4-4d1d-8e0f-a950273f4b8c/4stems/drums.mp3"
+                  }
+                }
+              },
+              "track_type": {
+                "S": "4stems"
+              }
+            }
+          }
+        ]
+      },
+      "song_id": {
+        "S": "e4a847fd-da00-4c32-ba4f-90e7a2847637"
       }
     },
     {
@@ -1133,6 +1259,47 @@
       },
       "song_id": {
         "S": "89e3a6fd-b74e-4bb8-82a3-e9eea7f08d5d"
+      }
+    },
+    {
+      "tracks": {
+        "L": [
+          {
+            "M": {
+              "id": {
+                "S": "c76e13ef-1faa-457c-9209-afd4ee3c501c"
+              },
+              "label": {
+                "S": "4stems"
+              },
+              "original_url": {
+                "S": "https://drive.google.com/uc?export=download&id=12qQLFJzaZdOuGzOIgPUq4O8iDknd2NJW"
+              },
+              "stem_urls": {
+                "M": {
+                  "vocals": {
+                    "S": "https://storage.googleapis.com/chord-paper-tracks/be9d7fab-a057-4011-8bf1-91427b1e8f53/c76e13ef-1faa-457c-9209-afd4ee3c501c/4stems/vocals.mp3"
+                  },
+                  "bass": {
+                    "S": "https://storage.googleapis.com/chord-paper-tracks/be9d7fab-a057-4011-8bf1-91427b1e8f53/c76e13ef-1faa-457c-9209-afd4ee3c501c/4stems/bass.mp3"
+                  },
+                  "other": {
+                    "S": "https://storage.googleapis.com/chord-paper-tracks/be9d7fab-a057-4011-8bf1-91427b1e8f53/c76e13ef-1faa-457c-9209-afd4ee3c501c/4stems/other.mp3"
+                  },
+                  "drums": {
+                    "S": "https://storage.googleapis.com/chord-paper-tracks/be9d7fab-a057-4011-8bf1-91427b1e8f53/c76e13ef-1faa-457c-9209-afd4ee3c501c/4stems/drums.mp3"
+                  }
+                }
+              },
+              "track_type": {
+                "S": "4stems"
+              }
+            }
+          }
+        ]
+      },
+      "song_id": {
+        "S": "be9d7fab-a057-4011-8bf1-91427b1e8f53"
       }
     },
     {
@@ -1474,14 +1641,14 @@
           },
           {
             "M": {
-              "id": {
-                "S": "839b75ff-7e8e-4b50-a876-832d1408f289"
-              },
               "label": {
                 "S": "Forever Love 4stem"
               },
-              "original_url": {
-                "S": "https://www.youtube.com/watch?v=5fqnfiwBfIo"
+              "id": {
+                "S": "839b75ff-7e8e-4b50-a876-832d1408f289"
+              },
+              "track_type": {
+                "S": "4stems"
               },
               "stem_urls": {
                 "M": {
@@ -1496,6 +1663,35 @@
                   },
                   "drums": {
                     "S": "https://storage.googleapis.com/chord-paper-tracks/2c3f4028-3aff-4dc9-8e6c-4f4cb9204e19/839b75ff-7e8e-4b50-a876-832d1408f289/4stems/drums.mp3"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "M": {
+              "id": {
+                "S": "4b04dcf8-24d7-41a5-b8e0-1c9b59a40b6f"
+              },
+              "label": {
+                "S": "However"
+              },
+              "original_url": {
+                "S": "https://www.youtube.com/watch?v=gPcPseeICjs"
+              },
+              "stem_urls": {
+                "M": {
+                  "vocals": {
+                    "S": "https://storage.googleapis.com/chord-paper-tracks/2c3f4028-3aff-4dc9-8e6c-4f4cb9204e19/4b04dcf8-24d7-41a5-b8e0-1c9b59a40b6f/4stems/vocals.mp3"
+                  },
+                  "bass": {
+                    "S": "https://storage.googleapis.com/chord-paper-tracks/2c3f4028-3aff-4dc9-8e6c-4f4cb9204e19/4b04dcf8-24d7-41a5-b8e0-1c9b59a40b6f/4stems/bass.mp3"
+                  },
+                  "other": {
+                    "S": "https://storage.googleapis.com/chord-paper-tracks/2c3f4028-3aff-4dc9-8e6c-4f4cb9204e19/4b04dcf8-24d7-41a5-b8e0-1c9b59a40b6f/4stems/other.mp3"
+                  },
+                  "drums": {
+                    "S": "https://storage.googleapis.com/chord-paper-tracks/2c3f4028-3aff-4dc9-8e6c-4f4cb9204e19/4b04dcf8-24d7-41a5-b8e0-1c9b59a40b6f/4stems/drums.mp3"
                   }
                 }
               },
@@ -2016,5 +2212,5 @@
       }
     }
   ],
-  "ScannedCount": 42
+  "ScannedCount": 46
 }

--- a/db_dump/TrackLists/schema.json
+++ b/db_dump/TrackLists/schema.json
@@ -7,7 +7,7 @@
       }
     ],
     "CreationDateTime": 1618018582.25,
-    "ItemCount": 42,
+    "ItemCount": 46,
     "KeySchema": [
       {
         "AttributeName": "song_id",
@@ -22,7 +22,7 @@
     "TableArn": "arn:aws:dynamodb:us-east-2:579696076733:table/TrackLists",
     "TableId": "4b68347c-cfba-4129-bb87-2f92881fe5e1",
     "TableName": "TrackLists",
-    "TableSizeBytes": 35037,
+    "TableSizeBytes": 38998,
     "TableStatus": "ACTIVE"
   }
 }

--- a/go-rewrite/src/server.go
+++ b/go-rewrite/src/server.go
@@ -75,15 +75,16 @@ func makeDynamoDB() *dynamo.DB {
 	dbSession := session.Must(session.NewSession())
 
 	config := aws.NewConfig().
-		WithRegion("us-east-2").
 		WithCredentials(credentials.NewEnvCredentials())
 
 	switch env.Get() {
 	case env.Production:
+		config = config.WithRegion("us-east-2")
 		return dynamo.New(dbSession, config)
 
 	case env.Development:
-		config = config.WithEndpoint("http://localhost:8000")
+		config = config.WithEndpoint("http://localhost:8000").
+			WithRegion("localhost")
 		return dynamo.New(dbSession, config)
 
 	default:


### PR DESCRIPTION
Setting a region for local use - this will allow concurrent use of a local instance of dynamodb for development and testing in the future.

The convention is that the region for development is "localhost". dynamodump puts it in this region even though it's nowhere specified that the region is that.

In addition, making a prod backup.