### PR TITLE
Go rewrite: update song endpoint

### DIFF
--- a/go-rewrite/src/errors/gateway/errors.go
+++ b/go-rewrite/src/errors/gateway/errors.go
@@ -16,8 +16,9 @@ var httpStatusCodeMap = map[api.ErrorCode]int{
 	auth.BadAuthorizationHeaderCode: http.StatusBadRequest,
 	auth.WrongOwnerCode:             http.StatusForbidden,
 	songerrors.SongNotFoundCode:     http.StatusNotFound,
-	songerrors.ExistingSongCode:     http.StatusUnprocessableEntity,
+	songerrors.ExistingSongCode:     http.StatusBadRequest,
 	songerrors.BadSongDataCode:      http.StatusBadRequest,
+	songerrors.SongOverwriteCode:    http.StatusBadRequest,
 }
 
 type JSONAPIError struct {

--- a/go-rewrite/src/lib/testing/song.go
+++ b/go-rewrite/src/lib/testing/song.go
@@ -3,7 +3,7 @@ package testlib
 import . "github.com/onsi/gomega"
 
 // compare most of the fields, except last saved at
-func ExpectEqualSongJSON(a map[string]interface{}, b map[string]interface{}) {
+func ExpectJSONEqualExceptLastSavedAt(a map[string]interface{}, b map[string]interface{}) {
 	a["lastSavedAt"] = nil
 	b["lastSavedAt"] = nil
 	Expect(a).To(Equal(b))

--- a/go-rewrite/src/server.go
+++ b/go-rewrite/src/server.go
@@ -33,6 +33,7 @@ type HTTPMethod string
 const (
 	GET    HTTPMethod = "GET"
 	POST   HTTPMethod = "POST"
+	PUT    HTTPMethod = "PUT"
 	DELETE HTTPMethod = "DELETE"
 
 	// should get injected as an env var, but YAGNI for now as it's not a secret
@@ -55,6 +56,8 @@ func main() {
 			e.GET(params())
 		case POST:
 			e.POST(params())
+		case PUT:
+			e.PUT(params())
 		case DELETE:
 			e.DELETE(params())
 		default:
@@ -76,6 +79,12 @@ func main() {
 	})
 
 	handleRoute(POST, "/songs", songGateway.CreateSong)
+
+	handleRoute(PUT, "/songs/:id", func(c echo.Context) error {
+		songID := c.Param("id")
+		return songGateway.UpdateSong(c, songID)
+	})
+
 	handleRoute(DELETE, "/songs/:id", func(c echo.Context) error {
 		songID := c.Param("id")
 		return songGateway.DeleteSong(c, songID)

--- a/go-rewrite/src/song/entity/song.go
+++ b/go-rewrite/src/song/entity/song.go
@@ -29,7 +29,7 @@ func (s *Song) CreateID() {
 	s.Defined.ID = uuid.New().String()
 }
 
-func (s *Song) SetSavedTime() {
+func (s *Song) SetSavedAtToNow() {
 	// truncate to seconds because this will be consumed by the browser
 	// and browser dates have only millisecond resolution
 

--- a/go-rewrite/src/song/errors/errors.go
+++ b/go-rewrite/src/song/errors/errors.go
@@ -5,7 +5,8 @@ import (
 )
 
 const (
-	SongNotFoundCode = api.ErrorCode("song_not_found")
-	ExistingSongCode = api.ErrorCode("create_song_exists")
-	BadSongDataCode  = api.ErrorCode("bad_song_data")
+	SongNotFoundCode  = api.ErrorCode("song_not_found")
+	ExistingSongCode  = api.ErrorCode("create_song_exists")
+	BadSongDataCode   = api.ErrorCode("bad_song_data")
+	SongOverwriteCode = api.ErrorCode("update_song_overwrite")
 )

--- a/go-rewrite/src/song/usecase/usecase.go
+++ b/go-rewrite/src/song/usecase/usecase.go
@@ -3,7 +3,6 @@ package songusecase
 import (
 	"context"
 	"github.com/cockroachdb/errors/markers"
-	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"github.com/veedubyou/chord-paper-be/go-rewrite/src/errors/api"
 	"github.com/veedubyou/chord-paper-be/go-rewrite/src/errors/auth"
@@ -26,7 +25,7 @@ func NewUsecase(db songstorage.DB, userUsecase userusecase.Usecase) Usecase {
 	}
 }
 
-func (u Usecase) GetSong(ctx context.Context, songID uuid.UUID) (songentity.Song, *api.Error) {
+func (u Usecase) GetSong(ctx context.Context, songID string) (songentity.Song, *api.Error) {
 	song, err := u.db.GetSong(ctx, songID)
 	if err != nil {
 		err = errors.Wrap(err, "Failed to get the song from DB")
@@ -116,7 +115,7 @@ func (u Usecase) CreateSong(ctx context.Context, authHeader string, song songent
 	}
 
 	song.CreateID()
-	song.SetSavedTime()
+	song.SetSavedAtToNow()
 	createdSong, err := u.db.CreateSong(ctx, song)
 	if err != nil {
 		return songentity.Song{}, api.CommitError(
@@ -128,8 +127,94 @@ func (u Usecase) CreateSong(ctx context.Context, authHeader string, song songent
 	return createdSong, nil
 }
 
-func (u Usecase) DeleteSong(ctx context.Context, authHeader string, songID uuid.UUID) *api.Error {
-	if apiErr := u.verifySongOwner(ctx, authHeader, songID); apiErr != nil {
+func (u Usecase) UpdateSong(ctx context.Context, authHeader string, songID string, song songentity.Song) (songentity.Song, *api.Error) {
+	dbSong, apiErr := u.GetSong(ctx, songID)
+	if apiErr != nil {
+		return songentity.Song{}, api.WrapError(apiErr, "Failed to fetch song")
+	}
+
+	freshlyFetchedSong := FreshlyFetchedSong(dbSong)
+
+	apiErr = u.verifySongOwnerBySong(ctx, authHeader, freshlyFetchedSong)
+	if apiErr != nil {
+		return songentity.Song{}, api.WrapError(apiErr, "Cannot verify that this user owns this song")
+	}
+
+	// set these security fields in case someone wants to pull a fast one
+	song.Defined.ID = freshlyFetchedSong.Defined.ID
+	song.Defined.Owner = freshlyFetchedSong.Defined.Owner
+
+	apiErr = protectSongFromOverwriting(song, freshlyFetchedSong)
+	if apiErr != nil {
+		return songentity.Song{}, api.WrapError(apiErr, "Song protected from overwriting")
+	}
+
+	song.SetSavedAtToNow()
+
+	updatedSong, err := u.db.UpdateSong(ctx, song)
+	if err != nil {
+		err = errors.Wrap(err, "Failed to update song in DB")
+		switch {
+		case markers.Is(err, songstorage.SongNotFoundMark):
+			return songentity.Song{}, api.CommitError(err,
+				songerrors.SongNotFoundCode,
+				"The song to be saved doesn't currently exist in the database")
+		case markers.Is(err, songstorage.DefaultErrorMark):
+			fallthrough
+		default:
+			return songentity.Song{}, api.CommitError(err,
+				api.DefaultErrorCode,
+				"Unknown error: Failed to save updated song")
+		}
+	}
+
+	return updatedSong, nil
+}
+
+func protectSongFromOverwriting(songToUpdate songentity.Song, songFromDB FreshlyFetchedSong) *api.Error {
+	if songToUpdate.Defined.LastSavedAt == nil {
+		err := errors.New("Song payload doesn't have a last saved at field set")
+		return api.CommitError(err,
+			songerrors.SongOverwriteCode,
+			"This song doesn't have a last saved at time, it may not have been created yet. Please upload the initial copy first")
+	}
+
+	if songFromDB.Defined.LastSavedAt == nil {
+		// unexpected, any song in the DB should have a last saved at
+		// but don't block on this
+		return nil
+	}
+
+	// prevent overwriting a more recent save if the last saved at timestamp is greater than the current one
+	// example:
+	// A --> B
+	//   \----->C
+	//
+	// Suppose I open the song at time A on two computers, make edits on both somewhat absentmindedly
+	// I first save at time B - the payload for the song for the last saved at would be A
+	// presume this succeeds, the server copy is now from time B and its last saved at time is also B
+	//
+	// Now I save another copy at time C, but the predecessor of my copy at time C was from A
+	// If I just go with last write wins, then all changes from the copy at time B would be overwritten
+	// So by comparing the timestamp at the save at C (A vs B), the save will fail to protect overwriting data.
+	//
+	// The user can then refetch the copy at time B and copy over their changes from time C (manual merge)
+	// and form a copy that will be accepted by the server:
+	//
+	// A --> B----->B+C
+	//   \----->C---/
+	if songToUpdate.Defined.LastSavedAt.Before(*songFromDB.Defined.LastSavedAt) {
+		err := errors.New("New song has an earlier last saved at than the current last saved time")
+		return api.CommitError(err,
+			songerrors.SongOverwriteCode,
+			"Unable to save - there's been a more recent copy of this song saved and saving it will clobber it. Please try reloading this song in a new tab and copy your work over")
+	}
+
+	return nil
+}
+
+func (u Usecase) DeleteSong(ctx context.Context, authHeader string, songID string) *api.Error {
+	if apiErr := u.verifySongOwnerBySongID(ctx, authHeader, songID); apiErr != nil {
 		return apiErr
 	}
 
@@ -154,13 +239,22 @@ func (u Usecase) DeleteSong(ctx context.Context, authHeader string, songID uuid.
 	return nil
 }
 
-func (u Usecase) verifySongOwner(ctx context.Context, authHeader string, songID uuid.UUID) *api.Error {
+func (u Usecase) verifySongOwnerBySongID(ctx context.Context, authHeader string, songID string) *api.Error {
 	song, apiErr := u.GetSong(ctx, songID)
 	if apiErr != nil {
 		return api.WrapError(apiErr, "Failed to fetch song")
 	}
 
-	apiErr = u.userUsecase.VerifyOwner(ctx, authHeader, song.Defined.Owner)
+	return u.verifySongOwnerBySong(ctx, authHeader, FreshlyFetchedSong(song))
+}
+
+// this type alias is to make it very explicit that the input is for a song that was just fetched
+// from the DB, not a song that was provided by the API caller. since they have the same type
+// it can be easy to just thread it through. the caller must acknowledge this difference through an explicit cast
+type FreshlyFetchedSong songentity.Song
+
+func (u Usecase) verifySongOwnerBySong(ctx context.Context, authHeader string, song FreshlyFetchedSong) *api.Error {
+	apiErr := u.userUsecase.VerifyOwner(ctx, authHeader, song.Defined.Owner)
 	if apiErr != nil {
 		return api.WrapError(apiErr, "Failed to verify song owner")
 	}

--- a/go-rewrite/src/track/gateway/gateway.go
+++ b/go-rewrite/src/track/gateway/gateway.go
@@ -1,13 +1,10 @@
 package trackgateway
 
 import (
-	"github.com/cockroachdb/errors"
-	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 	"github.com/veedubyou/chord-paper-be/go-rewrite/src/errors/api"
 	"github.com/veedubyou/chord-paper-be/go-rewrite/src/errors/gateway"
 	"github.com/veedubyou/chord-paper-be/go-rewrite/src/lib/request"
-	songerrors "github.com/veedubyou/chord-paper-be/go-rewrite/src/song/errors"
 	trackusecase "github.com/veedubyou/chord-paper-be/go-rewrite/src/track/usecase"
 	"net/http"
 )
@@ -22,17 +19,8 @@ func NewGateway(usecase trackusecase.Usecase) Gateway {
 	}
 }
 
-func (g Gateway) GetTrackList(c echo.Context, songIDStr string) error {
+func (g Gateway) GetTrackList(c echo.Context, songID string) error {
 	ctx := request.Context(c)
-
-	songID, err := uuid.Parse(songIDStr)
-	if err != nil {
-		err = errors.Wrap(err, "Failed to parse song ID for track list")
-		apiErr := api.CommitError(err,
-			songerrors.SongNotFoundCode,
-			"The song ID provided for the track list is invalid")
-		return gateway.ErrorResponse(c, apiErr)
-	}
 
 	tracklist, apiErr := g.usecase.GetTrackList(ctx, songID)
 	if apiErr != nil {

--- a/go-rewrite/src/track/storage/db.go
+++ b/go-rewrite/src/track/storage/db.go
@@ -3,7 +3,6 @@ package trackstorage
 import (
 	"context"
 	"github.com/cockroachdb/errors/markers"
-	"github.com/google/uuid"
 	"github.com/guregu/dynamo"
 	"github.com/pkg/errors"
 	dynamolib "github.com/veedubyou/chord-paper-be/go-rewrite/src/lib/dynamo"
@@ -25,10 +24,10 @@ func NewDB(dynamoDB dynamolib.DynamoDBWrapper) DB {
 	}
 }
 
-func (d DB) GetTrackList(ctx context.Context, songID uuid.UUID) (trackentity.TrackList, error) {
+func (d DB) GetTrackList(ctx context.Context, songID string) (trackentity.TrackList, error) {
 	value := dbTrackList{}
 	err := d.dynamoDB.Table(TracklistsTable).
-		Get(idKey, songID.String()).
+		Get(idKey, songID).
 		OneWithContext(ctx, &value)
 
 	if err != nil {

--- a/go-rewrite/src/track/usecase/usecase.go
+++ b/go-rewrite/src/track/usecase/usecase.go
@@ -3,7 +3,6 @@ package trackusecase
 import (
 	"context"
 	"github.com/cockroachdb/errors/markers"
-	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"github.com/veedubyou/chord-paper-be/go-rewrite/src/errors/api"
 	trackentity "github.com/veedubyou/chord-paper-be/go-rewrite/src/track/entity"
@@ -20,7 +19,7 @@ func NewUsecase(db trackstorage.DB) Usecase {
 	}
 }
 
-func (u Usecase) GetTrackList(ctx context.Context, songID uuid.UUID) (trackentity.TrackList, *api.Error) {
+func (u Usecase) GetTrackList(ctx context.Context, songID string) (trackentity.TrackList, *api.Error) {
 	tracklist, err := u.db.GetTrackList(ctx, songID)
 	if err != nil {
 		err = errors.Wrap(err, "Failed to get tracklist from DB")
@@ -28,7 +27,7 @@ func (u Usecase) GetTrackList(ctx context.Context, songID uuid.UUID) (trackentit
 		case markers.Is(err, trackstorage.TrackListNotFound):
 			// presume the model where all songs have a tracklist
 			// just whether they've been filled in or not
-			return trackentity.NewTrackList(songID.String()), nil
+			return trackentity.NewTrackList(songID), nil
 
 		case markers.Is(err, trackstorage.TrackListUnmarshalMark):
 			fallthrough


### PR DESCRIPTION
The update song endpoint.
A couple of changes from the original Rust implementation:
-the id and owner field is ensured to be the same as the DB copy instead of throwing an error
-UUIDs are not parsed anywhere, if an ID is not a UUID, just let it be caught as not found at the DB level. however empty strings need to be fenced at the DB level.