### PR TITLE
docker image prune no longer needed as runners are now ephemeral

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -45,9 +45,6 @@ jobs:
           version: v1.24.3
           command: set image --record deploy/chord-be-rust chord-be-rust=${{ secrets.DOCKERHUB_USERNAME }}/chord-be-rust:${{ env.gitver }}
 
-      - name: Cleanup Images
-        run: docker image prune -af
-          
       #- name: Setup GCloud CLI
       #  uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
       #  with:

--- a/.github/workflows/go-docker-image.yml
+++ b/.github/workflows/go-docker-image.yml
@@ -41,6 +41,3 @@ jobs:
           config: ${{ secrets.KUBE_CONFIG_DATA }}
           version: v1.24.3
           command: set image --record deploy/chord-be-go chord-be-go=${{ secrets.DOCKERHUB_USERNAME }}/chord-be-go:${{ env.gitver }}
-
-      - name: Cleanup Images
-        run: docker image prune -af


### PR DESCRIPTION
remove image prune (no longer needed)