### PR TITLE
change dockerfile once more

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -3,9 +3,9 @@ FROM golang:1.18.3-buster as builder
 WORKDIR /chord-paper-be/server
 
 COPY ./go.mod ./go.sum ./
-COPY ./server/src/ ./src/
+COPY ./server/src/ ./server/src/
 
-RUN go build -o chord-paper-be ./src/server.go
+RUN go build -o chord-paper-be ./server/src/server.go
 
 CMD ["./chord-paper-be"]
 

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -17,8 +17,8 @@ ENV PATH=$PATH:/usr/local/go/bin
 WORKDIR /chord-paper-be/worker
 
 COPY ./go.mod ./go.sum ./
-COPY ./worker/src/ ./src/
+COPY ./worker/src/ ./worker/src/
 
-RUN go build -o chord-paper-be-workers ./src/worker.go
+RUN go build -o chord-paper-be-workers ./worker/src/worker.go
  
 CMD ["./chord-paper-be-workers"]


### PR DESCRIPTION
changing the dockerfile commands again. I think the issue was that the relative path from the go mod file must be respected, so worker and server sources must also be in that relative path structure, and can't be hoisted up one level.