### PR TITLE
Reconnect and retry for queue publishing failures

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -30,6 +30,10 @@ jobs:
 
     services:
       dynamodb:
+        # anchoring to 1.19 because 1.20 breaks the region isolation somehow
+        # and causes tests to fail. the reason being that tests run in parallel
+        # by declaring different regions to isolate the data from each other
+        # but 1.20 somehow breaks that
         image: amazon/dynamodb-local:1.19.0
         ports:
           - 8000:8000

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -52,5 +52,5 @@ jobs:
         working-directory: ./src
         env:
           SKIP_SPLIT_TRACK_TEST: true
-        run: go test -v -p 1 ./...
+        run: go test -v ./...
         

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -30,7 +30,7 @@ jobs:
 
     services:
       dynamodb:
-        image: amazon/dynamodb-local
+        image: amazon/dynamodb-local:1.19
         ports:
           - 8000:8000
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -52,5 +52,5 @@ jobs:
         working-directory: ./src
         env:
           SKIP_SPLIT_TRACK_TEST: true
-        run: go test -v ./...
+        run: go test -v -p 1 ./...
         

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -30,7 +30,7 @@ jobs:
 
     services:
       dynamodb:
-        image: amazon/dynamodb-local:1.19
+        image: amazon/dynamodb-local:1.19.0
         ports:
           - 8000:8000
 

--- a/src/server/internal/track/track_test.go
+++ b/src/server/internal/track/track_test.go
@@ -29,7 +29,7 @@ var _ = Describe("Track", func() {
 	var (
 		trackGateway trackgateway.Gateway
 		songGateway  songgateway.Gateway
-		publisher    rabbitmq.QueuePublisher
+		publisher    *rabbitmq.QueuePublisher
 		validator    testing.Validator
 
 		consumer testing.RabbitMQConsumer

--- a/src/server/internal/track/usecase/usecase.go
+++ b/src/server/internal/track/usecase/usecase.go
@@ -18,10 +18,10 @@ import (
 type Usecase struct {
 	db          trackentity.Store
 	songUsecase songusecase.Usecase
-	publisher   rabbitmq.QueuePublisher
+	publisher   rabbitmq.Publisher
 }
 
-func NewUsecase(db trackentity.Store, songUsecase songusecase.Usecase, publisher rabbitmq.QueuePublisher) Usecase {
+func NewUsecase(db trackentity.Store, songUsecase songusecase.Usecase, publisher rabbitmq.Publisher) Usecase {
 	return Usecase{
 		db:          db,
 		songUsecase: songUsecase,

--- a/src/shared/testing/rabbitmq.go
+++ b/src/shared/testing/rabbitmq.go
@@ -21,8 +21,8 @@ func AfterSuiteRabbitMQ(conn *amqp091.Connection) {
 	ExpectSuccess(channel.QueueDelete(RabbitMQQueueName, false, false, false))
 }
 
-func MakeRabbitMQPublisher(conn *amqp091.Connection) rabbitmq.QueuePublisher {
-	publisher := ExpectSuccess(rabbitmq.NewQueuePublisher(conn, RabbitMQQueueName))
+func MakeRabbitMQPublisher(conn *amqp091.Connection) *rabbitmq.QueuePublisher {
+	publisher := ExpectSuccess(rabbitmq.NewQueuePublisherWithConnection(RabbitMQHost, conn, RabbitMQQueueName))
 	return publisher
 }
 

--- a/src/worker/application/app.go
+++ b/src/worker/application/app.go
@@ -54,10 +54,9 @@ type Config struct {
 
 func NewApp(config Config) App {
 	consumerConn := must(amqp091.Dial(config.RabbitMQURL))
-	producerConn := must(amqp091.Dial(config.RabbitMQURL))
 
 	return App{
-		worker: newWorker(config, consumerConn, producerConn),
+		worker: newWorker(config, consumerConn),
 	}
 }
 
@@ -74,8 +73,8 @@ func (a *App) Stop() {
 	a.worker.Stop()
 }
 
-func newWorker(config Config, consumerConn *amqp091.Connection, producerConn *amqp091.Connection) worker.QueueWorker {
-	publisher := newPublisher(config, producerConn)
+func newWorker(config Config, consumerConn *amqp091.Connection) worker.QueueWorker {
+	publisher := newPublisher(config)
 
 	trackStore := trackstorage.NewDB(newDynamoDB(config.DynamoConfig))
 	queueWorker := must(worker.NewQueueWorkerFromConnection(
@@ -86,8 +85,8 @@ func newWorker(config Config, consumerConn *amqp091.Connection, producerConn *am
 	return queueWorker
 }
 
-func newPublisher(config Config, conn *amqp091.Connection) rabbitmq.QueuePublisher {
-	publisher := must(rabbitmq.NewQueuePublisher(conn, config.RabbitMQQueueName))
+func newPublisher(config Config) *rabbitmq.QueuePublisher {
+	publisher := must(rabbitmq.NewQueuePublisher(config.RabbitMQURL, config.RabbitMQQueueName))
 	return publisher
 }
 


### PR DESCRIPTION
Adding a retry path - on occasion RabbitMQ would lose the connection. Attempting to see if just reconnecting would help blow away this whole class of publishing connection errors.