### PR TITLE
Don't block BE from starting if RabbitMQ is down

### DIFF
--- a/src/server/application/app.go
+++ b/src/server/application/app.go
@@ -149,12 +149,7 @@ func (a *App) Stop() error {
 }
 
 func makeRabbitMQPublisher(config Config) *rabbitmq.QueuePublisher {
-	publisher, err := rabbitmq.NewQueuePublisher(config.RabbitMQURL, config.RabbitMQQueueName)
-	if err != nil {
-		panic(errors.Wrap(err, "Failed to create rabbitMQ publisher"))
-	}
-
-	return publisher
+	return rabbitmq.NewQueuePublisher(config.RabbitMQURL, config.RabbitMQQueueName)
 }
 
 func makeDynamoDB(dynamoConfig config.Dynamo) dynamolib.DynamoDBWrapper {

--- a/src/server/internal/track/track_test.go
+++ b/src/server/internal/track/track_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Track", func() {
 
 	BeforeEach(func() {
 		validator = testing.Validator{}
-		publisher = testing.MakeRabbitMQPublisher()
+		publisher = testing.MakeRabbitMQPublisher(publisherConn)
 		consumer = testing.NewRabbitMQConsumer(consumerConn)
 
 		userStorage := userstorage.NewDB(db)

--- a/src/server/internal/track/track_test.go
+++ b/src/server/internal/track/track_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Track", func() {
 
 	BeforeEach(func() {
 		validator = testing.Validator{}
-		publisher = testing.MakeRabbitMQPublisher(publisherConn)
+		publisher = testing.MakeRabbitMQPublisher()
 		consumer = testing.NewRabbitMQConsumer(consumerConn)
 
 		userStorage := userstorage.NewDB(db)

--- a/src/worker/application/app.go
+++ b/src/worker/application/app.go
@@ -86,8 +86,7 @@ func newWorker(config Config, consumerConn *amqp091.Connection) worker.QueueWork
 }
 
 func newPublisher(config Config) *rabbitmq.QueuePublisher {
-	publisher := must(rabbitmq.NewQueuePublisher(config.RabbitMQURL, config.RabbitMQQueueName))
-	return publisher
+	return rabbitmq.NewQueuePublisher(config.RabbitMQURL, config.RabbitMQQueueName)
 }
 
 func newDynamoDB(dynamoConfig config.Dynamo) dynamolib.DynamoDBWrapper {


### PR DESCRIPTION
RabbitMQ can be down for various reasons. We can just shoot an error at the time of publish (as well as establishing the connection on the fly) - prevent this from blocking BE from starting the rest of it by taking out the error condition in the beginning.
