### PR TITLE
Switch to yt-dlp

### DIFF
--- a/docker/youtube-dl/Dockerfile
+++ b/docker/youtube-dl/Dockerfile
@@ -2,5 +2,5 @@ FROM alpine:latest
 
 RUN apk add curl 
 RUN mkdir /youtube-dl
-RUN curl -L https://yt-dl.org/downloads/latest/youtube-dl -o /home/youtube-dl
+RUN curl -L https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp -o /home/youtube-dl
 RUN chmod +x /home/youtube-dl

--- a/src/worker/worker.go
+++ b/src/worker/worker.go
@@ -38,7 +38,7 @@ func main() {
 	case env.Development:
 		appConfig = application.Config{
 			DynamoConfig: dev.DynamoConfig,
-			// using prod for now because the local fake GCS doesn't persist
+			// using prod GCS creds for now because the local fake GCS doesn't persist
 			CloudStorageConfig: config.ProdCloudStorage{
 				StorageHost: prod.GOOGLE_STORAGE_HOST,
 				SecretKey:   envvar.MustGet(envvar.GOOGLE_CLOUD_KEY),


### PR DESCRIPTION
Youtube-dl is dragging its feet fixing its releases. It's broken right now and cannot be used for youtube. Switching to yt-dlp for now