### PR TITLE
change image of youtube-dl container as well

### DIFF
--- a/.github/workflows/worker-prod-deploy.yml
+++ b/.github/workflows/worker-prod-deploy.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           config: ${{ secrets.KUBE_CONFIG_DATA }}
           version: v1.24.3
-          command: set image --record deploy/chord-be-workers chord-be-workers=${{ secrets.DOCKERHUB_USERNAME }}/chord-be-workers:${{ env.gitver }}
+          command: set image --record deploy/chord-be-workers chord-be-workers=${{ secrets.DOCKERHUB_USERNAME }}/chord-be-workers:${{ env.gitver }} youtube-dl-bin=${{ secrets.DOCKERHUB_USERNAME }}/youtube-dl-bin:${{ env.gitver }}
 
       - name: Verify K8S Deployment
         uses: steebchen/kubectl@master


### PR DESCRIPTION
apparently when the youtube-dl workflow was written, it was never updated to have kubernetes set the initContainer's image as well, so the only time the youtube-dl's container was updated was when the deployment was restarted manually.  Now the workflow has been updated to update the youtube-dl's container as well.