### PR TITLE
added worker resource request in deploy yaml

### DIFF
--- a/.k8s/worker/deploy.yml
+++ b/.k8s/worker/deploy.yml
@@ -31,6 +31,9 @@ spec:
         volumeMounts:
         - mountPath: /shared
           name: cache-volume
+        resources:
+          requests:
+            memory: 3Gi
       initContainers:
       - name: youtube-dl-bin
         image: pw1124/youtube-dl-bin:${LATEST_YOUTUBE_IMAGE}


### PR DESCRIPTION
- Reenable use of swap because the k8s feature is in beta now 
- New beta requirements to make a pod use swap: it has to have a memory resource request amount in the yaml
- Therefore, added memory resource request amount to yaml
- Swap is now enabled