### PR TITLE
Remove demucs-ft support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY : server-build server-test server-docker worker-build worker-test worker-docker test check
+.PHONY : server-build server-test server-docker worker-build worker-test worker-docker tests-build test check type-check
 
 server-build:
 	go build -o /dev/null -v ./src/server/server.go
@@ -23,6 +23,17 @@ worker-test:
 
 worker-docker:
 	docker build . --file ./docker/worker/Dockerfile
+
+tests-build:
+	@for pkg in $(shell find . -type f -name '*_test.go' -exec dirname {} \; | sort | uniq); do \
+		go test -c -o /dev/null $$pkg; \
+		if [ $$? -ne 0 ]; then \
+			echo "Tests in $$pkg failed to compile"; \
+			exit 1; \
+		fi; \
+	done
+
+type-check: server-build worker-build tests-build
 
 track-test:
 	go test -v ./src/shared/integration_test/...

--- a/src/shared/integration_test/track_split/track_split_test.go
+++ b/src/shared/integration_test/track_split/track_split_test.go
@@ -217,18 +217,6 @@ var _ = Describe("TrackSplit", func() {
 			},
 			{
 				SplitType:             "split_2stems",
-				EngineType:            "demucs-ft",
-				ExpectedCompletedType: "2stems",
-				ExpectedNumberOfStems: 2,
-			},
-			{
-				SplitType:             "split_4stems",
-				EngineType:            "demucs-ft",
-				ExpectedCompletedType: "4stems",
-				ExpectedNumberOfStems: 4,
-			},
-			{
-				SplitType:             "split_2stems",
 				EngineType:            "demucs-v3",
 				ExpectedCompletedType: "2stems",
 				ExpectedNumberOfStems: 2,

--- a/src/shared/track/entity/track.go
+++ b/src/shared/track/entity/track.go
@@ -42,17 +42,15 @@ var splitTrackTypes = map[string]bool{
 type SplitEngineType string
 
 const (
-	SpleeterType        SplitEngineType = "spleeter"
-	DemucsType          SplitEngineType = "demucs"
-	DemucsFineTunedType SplitEngineType = "demucs-ft"
-	DemucsV3Type        SplitEngineType = "demucs-v3"
+	SpleeterType SplitEngineType = "spleeter"
+	DemucsType   SplitEngineType = "demucs"
+	DemucsV3Type SplitEngineType = "demucs-v3"
 )
 
 var splitEngineTypes = map[string]bool{
-	string(SpleeterType):        true,
-	string(DemucsType):          true,
-	string(DemucsFineTunedType): true,
-	string(DemucsV3Type):        true,
+	string(SpleeterType): true,
+	string(DemucsType):   true,
+	string(DemucsV3Type): true,
 }
 
 type Tracks []Track

--- a/src/worker/internal/application/jobs/split/splitter/file_splitter/local_splitter.go
+++ b/src/worker/internal/application/jobs/split/splitter/file_splitter/local_splitter.go
@@ -82,8 +82,6 @@ func (l LocalFileSplitter) SplitFile(ctx context.Context, originalTrackFilePath 
 
 	case trackentity.DemucsType:
 		fallthrough
-	case trackentity.DemucsFineTunedType:
-		fallthrough
 	case trackentity.DemucsV3Type:
 		filePaths, err := l.runDemucs(absOriginalTrackFilePath, absStemsOutputDir, splitType, engineType)
 		if err != nil {
@@ -113,8 +111,6 @@ func (l LocalFileSplitter) runDemucs(sourcePath string, destPath string, splitTy
 	switch engineType {
 	case trackentity.DemucsType:
 		model = "htdemucs"
-	case trackentity.DemucsFineTunedType:
-		model = "htdemucs_ft"
 	case trackentity.DemucsV3Type:
 		model = "hdemucs_mmi"
 	default:


### PR DESCRIPTION
Demucs FT is too resource intensive to use for real. It's also not worth the wait, so removing this.